### PR TITLE
Moved hardcoded values to to environment variables

### DIFF
--- a/src/lib/DataWorker.js
+++ b/src/lib/DataWorker.js
@@ -40,6 +40,7 @@ function verify(val1, operator, val2) {
 
 /**
  * Main worker method used to check scraper data against threshold
+ * @param {String} userJwt Parent's user JSON web token value (needed to retrieve data)
  */
 async function checkData(userJwt) {
   try {


### PR DESCRIPTION
This patch fixes #31 
All data worker's hardcoded values are moved and loaded from environment variables.