### PR TITLE
Added release bundle smoke test files to CD flow

### DIFF
--- a/.github/actions/prepare-release-artifact/action.yml
+++ b/.github/actions/prepare-release-artifact/action.yml
@@ -1,0 +1,61 @@
+name: Prepare release artifact
+description: Resolve release bundle tag, download workflow artifact, and optionally extract it.
+
+inputs:
+  artifactPath:
+    description: Directory where artifact tarball should be downloaded.
+    required: false
+    default: smoke
+  extract:
+    description: Whether to extract the downloaded tarball.
+    required: false
+    default: "false"
+  extractPath:
+    description: Directory where tarball should be extracted.
+    required: false
+    default: extracted
+
+outputs:
+  bundle_tag:
+    description: Resolved release bundle tag.
+    value: ${{ steps.resolve.outputs.bundle_tag }}
+  archive_path:
+    description: Full path to the downloaded tarball.
+    value: ${{ steps.resolve.outputs.archive_path }}
+  extract_path:
+    description: Full path to extraction directory.
+    value: ${{ steps.resolve.outputs.extract_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve bundle tag
+      id: resolve
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "release" ]; then
+          BUNDLE_TAG="${{ github.event.release.tag_name }}"
+        else
+          BUNDLE_TAG="manual-${{ github.run_number }}"
+        fi
+
+        ARTIFACT_PATH="${{ inputs.artifactPath }}"
+        EXTRACT_PATH="$ARTIFACT_PATH/${{ inputs.extractPath }}"
+        ARCHIVE_PATH="$ARTIFACT_PATH/data-monitor-${BUNDLE_TAG}.tar.gz"
+
+        echo "bundle_tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"
+        echo "archive_path=$ARCHIVE_PATH" >> "$GITHUB_OUTPUT"
+        echo "extract_path=$EXTRACT_PATH" >> "$GITHUB_OUTPUT"
+
+    - name: Download release artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: data-monitor-${{ steps.resolve.outputs.bundle_tag }}
+        path: ${{ inputs.artifactPath }}
+
+    - name: Extract artifact
+      if: ${{ inputs.extract == 'true' }}
+      shell: bash
+      run: |
+        mkdir -p "${{ steps.resolve.outputs.extract_path }}"
+        tar -xzf "${{ steps.resolve.outputs.archive_path }}" -C "${{ steps.resolve.outputs.extract_path }}"

--- a/.github/actions/prepare-release-artifact/action.yml
+++ b/.github/actions/prepare-release-artifact/action.yml
@@ -18,13 +18,13 @@ inputs:
 outputs:
   bundle_tag:
     description: Resolved release bundle tag.
-    value: ${{ steps.resolve.outputs.bundle_tag }}
+    value: ${{ steps.tag.outputs.bundle_tag }}
   archive_path:
     description: Full path to the downloaded tarball.
-    value: ${{ steps.resolve.outputs.archive_path }}
+    value: ${{ steps.archive.outputs.archive_path }}
   extract_path:
     description: Full path to extraction directory.
-    value: ${{ steps.resolve.outputs.extract_path }}
+    value: ${{ steps.paths.outputs.extract_path }}
 
 runs:
   using: composite
@@ -34,15 +34,12 @@ runs:
       uses: ./.github/actions/resolve-bundle-tag
 
     - name: Resolve artifact paths
-      id: resolve
+      id: paths
       shell: bash
       run: |
         ARTIFACT_PATH="${{ inputs.artifactPath }}"
         EXTRACT_PATH="$ARTIFACT_PATH/${{ inputs.extractPath }}"
-        ARCHIVE_PATH="$ARTIFACT_PATH/data-monitor-${{ steps.tag.outputs.bundle_tag }}.tar.gz"
 
-        echo "bundle_tag=${{ steps.tag.outputs.bundle_tag }}" >> "$GITHUB_OUTPUT"
-        echo "archive_path=$ARCHIVE_PATH" >> "$GITHUB_OUTPUT"
         echo "extract_path=$EXTRACT_PATH" >> "$GITHUB_OUTPUT"
 
     - name: Download release artifact
@@ -51,9 +48,24 @@ runs:
         name: data-monitor-${{ steps.tag.outputs.bundle_tag }}
         path: ${{ inputs.artifactPath }}
 
+    - name: Resolve downloaded archive path
+      id: archive
+      shell: bash
+      run: |
+        ARCHIVE_NAME="data-monitor-${{ steps.tag.outputs.bundle_tag }}.tar.gz"
+        ARCHIVE_PATH=$(find "${{ inputs.artifactPath }}" -type f -name "$ARCHIVE_NAME" | head -n 1)
+
+        if [ -z "$ARCHIVE_PATH" ]; then
+          echo "Cannot find downloaded archive: $ARCHIVE_NAME"
+          find "${{ inputs.artifactPath }}" -maxdepth 3 -type f || true
+          exit 1
+        fi
+
+        echo "archive_path=$ARCHIVE_PATH" >> "$GITHUB_OUTPUT"
+
     - name: Extract artifact
       if: ${{ inputs.extract == 'true' }}
       shell: bash
       run: |
-        mkdir -p "${{ steps.resolve.outputs.extract_path }}"
-        tar -xzf "${{ steps.resolve.outputs.archive_path }}" -C "${{ steps.resolve.outputs.extract_path }}"
+        mkdir -p "${{ steps.paths.outputs.extract_path }}"
+        tar -xzf "${{ steps.archive.outputs.archive_path }}" -C "${{ steps.paths.outputs.extract_path }}"

--- a/.github/actions/prepare-release-artifact/action.yml
+++ b/.github/actions/prepare-release-artifact/action.yml
@@ -30,27 +30,25 @@ runs:
   using: composite
   steps:
     - name: Resolve bundle tag
+      id: tag
+      uses: ./.github/actions/resolve-bundle-tag
+
+    - name: Resolve artifact paths
       id: resolve
       shell: bash
       run: |
-        if [ "${{ github.event_name }}" = "release" ]; then
-          BUNDLE_TAG="${{ github.event.release.tag_name }}"
-        else
-          BUNDLE_TAG="manual-${{ github.run_number }}"
-        fi
-
         ARTIFACT_PATH="${{ inputs.artifactPath }}"
         EXTRACT_PATH="$ARTIFACT_PATH/${{ inputs.extractPath }}"
-        ARCHIVE_PATH="$ARTIFACT_PATH/data-monitor-${BUNDLE_TAG}.tar.gz"
+        ARCHIVE_PATH="$ARTIFACT_PATH/data-monitor-${{ steps.tag.outputs.bundle_tag }}.tar.gz"
 
-        echo "bundle_tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"
+        echo "bundle_tag=${{ steps.tag.outputs.bundle_tag }}" >> "$GITHUB_OUTPUT"
         echo "archive_path=$ARCHIVE_PATH" >> "$GITHUB_OUTPUT"
         echo "extract_path=$EXTRACT_PATH" >> "$GITHUB_OUTPUT"
 
     - name: Download release artifact
       uses: actions/download-artifact@v4
       with:
-        name: data-monitor-${{ steps.resolve.outputs.bundle_tag }}
+        name: data-monitor-${{ steps.tag.outputs.bundle_tag }}
         path: ${{ inputs.artifactPath }}
 
     - name: Extract artifact

--- a/.github/actions/prepare-release-artifact/action.yml
+++ b/.github/actions/prepare-release-artifact/action.yml
@@ -53,13 +53,21 @@ runs:
       shell: bash
       run: |
         ARCHIVE_NAME="data-monitor-${{ steps.tag.outputs.bundle_tag }}.tar.gz"
-        ARCHIVE_PATH=$(find "${{ inputs.artifactPath }}" -type f -name "$ARCHIVE_NAME" | head -n 1)
+        mapfile -t MATCHED_ARCHIVES < <(find "${{ inputs.artifactPath }}" -type f -name "$ARCHIVE_NAME")
 
-        if [ -z "$ARCHIVE_PATH" ]; then
+        if [ "${#MATCHED_ARCHIVES[@]}" -eq 0 ]; then
           echo "Cannot find downloaded archive: $ARCHIVE_NAME"
           find "${{ inputs.artifactPath }}" -maxdepth 3 -type f || true
           exit 1
         fi
+
+        if [ "${#MATCHED_ARCHIVES[@]}" -gt 1 ]; then
+          echo "Multiple archive matches found for: $ARCHIVE_NAME"
+          printf ' - %s\n' "${MATCHED_ARCHIVES[@]}"
+          exit 1
+        fi
+
+        ARCHIVE_PATH="${MATCHED_ARCHIVES[0]}"
 
         echo "archive_path=$ARCHIVE_PATH" >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/resolve-bundle-tag/action.yml
+++ b/.github/actions/resolve-bundle-tag/action.yml
@@ -1,0 +1,22 @@
+name: Resolve bundle tag
+description: Resolve release bundle tag from event context.
+
+outputs:
+  bundle_tag:
+    description: Resolved release bundle tag.
+    value: ${{ steps.resolve.outputs.bundle_tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve bundle tag
+      id: resolve
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "release" ]; then
+          BUNDLE_TAG="${{ github.event.release.tag_name }}"
+        else
+          BUNDLE_TAG="manual-${{ github.run_number }}"
+        fi
+
+        echo "bundle_tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/release-bundle-files.txt
+++ b/.github/release-bundle-files.txt
@@ -1,0 +1,15 @@
+# Release bundle contents (one path per line, relative to repository root)
+package.json
+package-lock.json
+next.config.mjs
+eslint.config.mjs
+jsconfig.json
+postcss.config.mjs
+Dockerfile
+.dockerignore
+docker-compose.yml
+README.md
+LICENSE
+VERSION
+public
+src

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -66,21 +66,9 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
+          grep -vE '^\s*($|#)' .github/release-bundle-files.txt > dist/release-files.txt
           tar -czf "dist/data-monitor-${{ steps.tag.outputs.bundle_tag }}.tar.gz" \
-            package.json \
-            package-lock.json \
-            next.config.mjs \
-            eslint.config.mjs \
-            jsconfig.json \
-            postcss.config.mjs \
-            Dockerfile \
-            .dockerignore \
-            docker-compose.yml \
-            README.md \
-            LICENSE \
-            VERSION \
-            public \
-            src
+            --files-from=dist/release-files.txt
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
@@ -109,24 +97,14 @@ jobs:
       - name: Verify required files
         shell: bash
         run: |
-          required=(
-            package.json
-            package-lock.json
-            Dockerfile
-            .dockerignore
-            docker-compose.yml
-            README.md
-            VERSION
-            src
-            public
-          )
+          grep -vE '^\s*($|#)' .github/release-bundle-files.txt > smoke/required-files.txt
 
-          for file in "${required[@]}"; do
+          while IFS= read -r file; do
             if [ ! -e "smoke/extracted/$file" ]; then
               echo "Missing required artifact entry: $file"
               exit 1
             fi
-          done
+          done < smoke/required-files.txt
 
           echo "Artifact smoke check passed."
 

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          grep -vE '^\s*($|#)' .github/release-bundle-files.txt > dist/release-files.txt
+          grep -vE '^[[:space:]]*($|#)' .github/release-bundle-files.txt > dist/release-files.txt
           tar -czf "dist/data-monitor-${{ steps.tag.outputs.bundle_tag }}.tar.gz" \
             --files-from=dist/release-files.txt
 
@@ -97,7 +97,7 @@ jobs:
       - name: Verify required files
         shell: bash
         run: |
-          grep -vE '^\s*($|#)' .github/release-bundle-files.txt > smoke/required-files.txt
+          grep -vE '^[[:space:]]*($|#)' .github/release-bundle-files.txt > smoke/required-files.txt
 
           while IFS= read -r file; do
             if [ ! -e "smoke/extracted/$file" ]; then

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -99,3 +99,55 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/data-monitor-${{ env.BUNDLE_TAG }}.tar.gz
+
+  smoke-artifact:
+    name: Smoke Check Artifact
+    needs: bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Resolve bundle tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "BUNDLE_TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+          else
+            echo "BUNDLE_TAG=manual-${{ github.run_number }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: data-monitor-${{ env.BUNDLE_TAG }}
+          path: smoke
+
+      - name: Extract artifact
+        shell: bash
+        run: |
+          mkdir -p smoke/extracted
+          tar -xzf "smoke/data-monitor-${BUNDLE_TAG}.tar.gz" -C smoke/extracted
+
+      - name: Verify required files
+        shell: bash
+        run: |
+          required=(
+            package.json
+            package-lock.json
+            Dockerfile
+            .dockerignore
+            docker-compose.yml
+            README.md
+            VERSION
+            src
+            public
+          )
+
+          for file in "${required[@]}"; do
+            if [ ! -e "smoke/extracted/$file" ]; then
+              echo "Missing required artifact entry: $file"
+              exit 1
+            fi
+          done
+
+          echo "Artifact smoke check passed."

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -141,11 +141,11 @@ jobs:
         run: |
           docker compose -f runtime/extracted/docker-compose.yml up --build -d postgres web
 
-      - name: Probe web endpoint
+      - name: Probe health endpoint
         shell: bash
         run: |
           for attempt in {1..30}; do
-            code=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:3000 || true)
+            code=$(curl -sS -o /dev/null -w "%{http_code}" -X HEAD http://127.0.0.1:3000/api/health || true)
             if [ "$code" = "200" ]; then
               echo "Runtime smoke check passed."
               exit 0
@@ -153,7 +153,7 @@ jobs:
             sleep 5
           done
 
-          echo "Web endpoint did not become ready in time."
+          echo "Health endpoint did not become ready in time."
           docker compose -f runtime/extracted/docker-compose.yml logs web
           exit 1
 

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -94,12 +94,6 @@ jobs:
           path: dist/data-monitor-${{ env.BUNDLE_TAG }}.tar.gz
           if-no-files-found: error
 
-      - name: Attach archive to GitHub release
-        if: ${{ github.event_name == 'release' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/data-monitor-${{ env.BUNDLE_TAG }}.tar.gz
-
   smoke-artifact:
     name: Smoke Check Artifact
     needs: bundle
@@ -217,3 +211,27 @@ jobs:
         shell: bash
         run: |
           docker compose -f runtime/extracted/docker-compose.yml down -v --remove-orphans
+
+  publish-release-asset:
+    name: Publish Release Asset
+    needs: smoke-runtime
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Resolve bundle tag
+        shell: bash
+        run: |
+          echo "BUNDLE_TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: data-monitor-${{ env.BUNDLE_TAG }}
+          path: publish
+
+      - name: Attach archive to GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: publish/data-monitor-${{ env.BUNDLE_TAG }}.tar.gz

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -139,7 +139,11 @@ jobs:
       - name: Start smoke stack (postgres + web)
         shell: bash
         run: |
-          docker compose -f runtime/extracted/docker-compose.yml up --build -d postgres web
+          docker compose \
+            --project-directory runtime/extracted \
+            --env-file runtime/extracted/.env \
+            -f runtime/extracted/docker-compose.yml \
+            up --build -d postgres web
 
       - name: Probe health endpoint
         shell: bash
@@ -154,14 +158,22 @@ jobs:
           done
 
           echo "Health endpoint did not become ready in time."
-          docker compose -f runtime/extracted/docker-compose.yml logs web
+          docker compose \
+            --project-directory runtime/extracted \
+            --env-file runtime/extracted/.env \
+            -f runtime/extracted/docker-compose.yml \
+            logs web
           exit 1
 
       - name: Teardown smoke stack
         if: ${{ always() }}
         shell: bash
         run: |
-          docker compose -f runtime/extracted/docker-compose.yml down -v --remove-orphans
+          docker compose \
+            --project-directory runtime/extracted \
+            --env-file runtime/extracted/.env \
+            -f runtime/extracted/docker-compose.yml \
+            down -v --remove-orphans
 
   publish-release-asset:
     name: Publish Release Asset

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -52,13 +52,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Resolve bundle tag
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "BUNDLE_TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
-          else
-            echo "BUNDLE_TAG=manual-${{ github.run_number }}" >> "$GITHUB_ENV"
-          fi
+        id: tag
+        uses: ./.github/actions/resolve-bundle-tag
 
       - name: Generate VERSION metadata
         shell: bash
@@ -71,7 +66,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          tar -czf "dist/data-monitor-${BUNDLE_TAG}.tar.gz" \
+          tar -czf "dist/data-monitor-${{ steps.tag.outputs.bundle_tag }}.tar.gz" \
             package.json \
             package-lock.json \
             next.config.mjs \
@@ -90,8 +85,8 @@ jobs:
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: data-monitor-${{ env.BUNDLE_TAG }}
-          path: dist/data-monitor-${{ env.BUNDLE_TAG }}.tar.gz
+          name: data-monitor-${{ steps.tag.outputs.bundle_tag }}
+          path: dist/data-monitor-${{ steps.tag.outputs.bundle_tag }}.tar.gz
           if-no-files-found: error
 
   smoke-artifact:

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -101,26 +101,15 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Resolve bundle tag
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "BUNDLE_TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
-          else
-            echo "BUNDLE_TAG=manual-${{ github.run_number }}" >> "$GITHUB_ENV"
-          fi
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Download release artifact
-        uses: actions/download-artifact@v4
+      - name: Prepare release artifact
+        uses: ./.github/actions/prepare-release-artifact
         with:
-          name: data-monitor-${{ env.BUNDLE_TAG }}
-          path: smoke
-
-      - name: Extract artifact
-        shell: bash
-        run: |
-          mkdir -p smoke/extracted
-          tar -xzf "smoke/data-monitor-${BUNDLE_TAG}.tar.gz" -C smoke/extracted
+          artifactPath: smoke
+          extract: "true"
+          extractPath: extracted
 
       - name: Verify required files
         shell: bash
@@ -153,26 +142,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Resolve bundle tag
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "BUNDLE_TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
-          else
-            echo "BUNDLE_TAG=manual-${{ github.run_number }}" >> "$GITHUB_ENV"
-          fi
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Download release artifact
-        uses: actions/download-artifact@v4
+      - name: Prepare release artifact
+        uses: ./.github/actions/prepare-release-artifact
         with:
-          name: data-monitor-${{ env.BUNDLE_TAG }}
-          path: runtime
-
-      - name: Extract artifact
-        shell: bash
-        run: |
-          mkdir -p runtime/extracted
-          tar -xzf "runtime/data-monitor-${BUNDLE_TAG}.tar.gz" -C runtime/extracted
+          artifactPath: runtime
+          extract: "true"
+          extractPath: extracted
 
       - name: Create smoke test env file
         shell: bash
@@ -220,18 +198,16 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Resolve bundle tag
-        shell: bash
-        run: |
-          echo "BUNDLE_TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Download release artifact
-        uses: actions/download-artifact@v4
+      - name: Prepare release artifact
+        id: artifact
+        uses: ./.github/actions/prepare-release-artifact
         with:
-          name: data-monitor-${{ env.BUNDLE_TAG }}
-          path: publish
+          artifactPath: publish
 
       - name: Attach archive to GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: publish/data-monitor-${{ env.BUNDLE_TAG }}.tar.gz
+          files: publish/data-monitor-${{ steps.artifact.outputs.bundle_tag }}.tar.gz

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -183,4 +183,4 @@ jobs:
       - name: Attach archive to GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: publish/data-monitor-${{ steps.artifact.outputs.bundle_tag }}.tar.gz
+          files: ${{ steps.artifact.outputs.archive_path }}

--- a/.github/workflows/cd-data-monitor.yml
+++ b/.github/workflows/cd-data-monitor.yml
@@ -151,3 +151,69 @@ jobs:
           done
 
           echo "Artifact smoke check passed."
+
+  smoke-runtime:
+    name: Smoke Check Runtime
+    needs: smoke-artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Resolve bundle tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "BUNDLE_TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+          else
+            echo "BUNDLE_TAG=manual-${{ github.run_number }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: data-monitor-${{ env.BUNDLE_TAG }}
+          path: runtime
+
+      - name: Extract artifact
+        shell: bash
+        run: |
+          mkdir -p runtime/extracted
+          tar -xzf "runtime/data-monitor-${BUNDLE_TAG}.tar.gz" -C runtime/extracted
+
+      - name: Create smoke test env file
+        shell: bash
+        run: |
+          cat > runtime/extracted/.env << 'EOF'
+          APP_PORT=3000
+          DB_NAME=data_monitor
+          DB_USER=data_monitor
+          DB_PASS=smoke_test_password
+          CRYPTO_SECRET=smoke_test_secret_value_for_ci_only
+          EOF
+
+      - name: Start smoke stack (postgres + web)
+        shell: bash
+        run: |
+          docker compose -f runtime/extracted/docker-compose.yml up --build -d postgres web
+
+      - name: Probe web endpoint
+        shell: bash
+        run: |
+          for attempt in {1..30}; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:3000 || true)
+            if [ "$code" = "200" ]; then
+              echo "Runtime smoke check passed."
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "Web endpoint did not become ready in time."
+          docker compose -f runtime/extracted/docker-compose.yml logs web
+          exit 1
+
+      - name: Teardown smoke stack
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          docker compose -f runtime/extracted/docker-compose.yml down -v --remove-orphans


### PR DESCRIPTION
This patch fixes #87 
New smoke tests added after creating release bundle which is now verified for completness and runtime. When both of those steps are correct then (and only then) a package is published officially.