### PR TITLE
Fix data worker error after UI login

### DIFF
--- a/src/app/api/init/route.js
+++ b/src/app/api/init/route.js
@@ -66,7 +66,7 @@ export async function GET(request) {
     await migrateSensitiveData();
     const featuresResponse = await ScraperRequest.GET(AppConfig.getConfig().scraper.endpoints.features);
     if (!featuresResponse.ok) {
-      const result = { init: false, message: await featuresResponse.text() };
+      const result = { init: false, message: await RequestUtils.getResponseMessage(featuresResponse) };
       return new Response(JSON.stringify(result), {
         status: featuresResponse.status,
         headers: { "Content-Type": "application/json" },

--- a/src/app/monitors/page.js
+++ b/src/app/monitors/page.js
@@ -5,6 +5,7 @@ import { toast } from "react-toastify";
 import { LoginContext, PageContext } from "@/context/Contexts";
 import UserAccess from "@/components/UserAccess";
 import MonitorsPage from "@/views/MonitorsPage";
+import { RequestUtils } from "@/lib/RequestUtils";
 
 export default function Monitors() {
   const MAX_ATTEMPTS = 5;
@@ -31,7 +32,7 @@ export default function Monitors() {
             toast.warn("Waiting for demo initialization...");
             await new Promise((res) => setTimeout(res, WAIT_TIME_MS));
           } else {
-            const message = await response.text();
+            const message = await RequestUtils.getResponseMessage(response);
             toast.error(message);
             return;
           }

--- a/src/components/DataMonitor.jsx
+++ b/src/components/DataMonitor.jsx
@@ -29,25 +29,6 @@ const parseNotifierValue = (input) => {
   return { type, id: Number.isNaN(id) ? null : id };
 };
 
-const getResponseMessage = async (response) => {
-  try {
-    const payload = await response.json();
-    if (typeof payload === "string") {
-      return payload;
-    }
-    if (payload?.message) {
-      return String(payload.message);
-    }
-    return JSON.stringify(payload);
-  } catch {
-    try {
-      return await response.text();
-    } catch {
-      return "No response details available.";
-    }
-  }
-};
-
 const DataMonitor = ({ parentName }) => {
   const parentId = DataUtils.nameToId(parentName);
   const { isDemo, userId, email, token } = useContext(LoginContext);
@@ -238,7 +219,7 @@ const DataMonitor = ({ parentName }) => {
           details: { message, data: "123.456", threshold },
         }),
       });
-      const responseMessage = await getResponseMessage(notifyResponse);
+      const responseMessage = await RequestUtils.getResponseMessage(notifyResponse);
       if (!notifyResponse.ok) {
         toast.error(`Test notification ERROR: ${responseMessage}`);
         return;

--- a/src/components/DataMonitor.jsx
+++ b/src/components/DataMonitor.jsx
@@ -29,6 +29,25 @@ const parseNotifierValue = (input) => {
   return { type, id: Number.isNaN(id) ? null : id };
 };
 
+const getResponseMessage = async (response) => {
+  try {
+    const payload = await response.json();
+    if (typeof payload === "string") {
+      return payload;
+    }
+    if (payload?.message) {
+      return String(payload.message);
+    }
+    return JSON.stringify(payload);
+  } catch {
+    try {
+      return await response.text();
+    } catch {
+      return "No response details available.";
+    }
+  }
+};
+
 const DataMonitor = ({ parentName }) => {
   const parentId = DataUtils.nameToId(parentName);
   const { isDemo, userId, email, token } = useContext(LoginContext);
@@ -219,11 +238,12 @@ const DataMonitor = ({ parentName }) => {
           details: { message, data: "123.456", threshold },
         }),
       });
+      const responseMessage = await getResponseMessage(notifyResponse);
       if (!notifyResponse.ok) {
-        toast.error(`Test notification ERROR: ${await notifyResponse.json()}`);
+        toast.error(`Test notification ERROR: ${responseMessage}`);
         return;
       }
-      toast.success(`Test notification OK: ${await notifyResponse.json()}`);
+      toast.success(`Test notification OK: ${responseMessage}`);
     } catch (e) {
       toast.error(`Error: ${e.message}`);
     }

--- a/src/components/NotifierCard.jsx
+++ b/src/components/NotifierCard.jsx
@@ -22,9 +22,8 @@ const NotifierCard = ({ data, options, onChange, onDelete }) => {
         headers: { "Content-Type": "application/json", ...getAuthHeaders() },
         body: JSON.stringify({ ...notifier, user: data.user }),
       });
-      const notifierData = await notifierResponse.json();
       if (!notifierResponse.ok) {
-        toast.error(notifierData.message);
+        toast.error(await RequestUtils.getResponseMessage(notifierResponse));
         return;
       }
       onChange();
@@ -44,9 +43,8 @@ const NotifierCard = ({ data, options, onChange, onDelete }) => {
         method: "DELETE",
         headers: { "Content-Type": "application/json", ...getAuthHeaders() },
       });
-      const notifierData = await notifierResponse.json();
       if (!notifierResponse.ok) {
-        toast.error(notifierData.message);
+        toast.error(await RequestUtils.getResponseMessage(notifierResponse));
         return;
       }
       onDelete(data.id);

--- a/src/lib/DataWorker.js
+++ b/src/lib/DataWorker.js
@@ -236,12 +236,29 @@ async function checkData(user) {
   }
   RUNNING_USER_CHECKS.add(userCheckKey);
   try {
+    let currentUser = user;
+    if (user?.id != null) {
+      try {
+        const users = await UserService.filterUsers({ id: user.id });
+        if (users.length !== 1) {
+          workerWarn("Cannot refresh user credentials for this run. Skipping check.", user);
+          return;
+        }
+        currentUser = users[0];
+      } catch (error) {
+        workerError(`Cannot refresh user credentials: ${error.message}`, user);
+        return;
+      }
+    }
     // filter out enabled monitors which were not notified in their timeframe (cooldown)
-    const enabledMonitors = await MonitorService.filterMonitors({ user: user.id, enabled: true });
+    const enabledMonitors = await MonitorService.filterMonitors({ user: currentUser.id, enabled: true });
     const monitorsToCheck = enabledMonitors.filter((monitor) => {
       const sendInterval = monitor.interval || SEND_INTERVAL;
-      if (checkSendTimestamp(user, monitor.parent, sendInterval)) {
-        workerInfo(`Skipping ${monitor.parent}: Notification was sent in the last ${sendInterval / 1_000} seconds.`, user);
+      if (checkSendTimestamp(currentUser, monitor.parent, sendInterval)) {
+        workerInfo(
+          `Skipping ${monitor.parent}: Notification was sent in the last ${sendInterval / 1_000} seconds.`,
+          currentUser,
+        );
         return false;
       }
       return true;
@@ -254,19 +271,19 @@ async function checkData(user) {
     try {
       scraperResponse = await RequestUtils.fetchWithRetry(`${SERVER_ADDRESS}/api/scraper/items`, {
         method: "GET",
-        headers: { Authorization: `Bearer ${user.jwt}` },
+        headers: { Authorization: `Bearer ${currentUser.jwt}` },
       });
     } catch (error) {
-      workerError(`Cannot fetch scraper data: ${error.message}`, user);
+      workerError(`Cannot fetch scraper data: ${error.message}`, currentUser);
       return;
     }
     if (!scraperResponse.ok) {
-      workerError(`Cannot get scraper data: ${await scraperResponse.text()}`, user);
+      workerError(`Cannot get scraper data: ${await scraperResponse.text()}`, currentUser);
       return;
     }
     const scraperData = await scraperResponse.json();
     if (!Array.isArray(scraperData)) {
-      workerError("Cannot parse scraper data response.", user);
+      workerError("Cannot parse scraper data response.", currentUser);
       return;
     }
     const scraperDataByName = new Map();
@@ -288,15 +305,15 @@ async function checkData(user) {
             const monitorItemId = DataUtils.nameToId(monitor.parent);
             const scraperItem = scraperDataByName.get(monitorItemId);
             if (!scraperItem) {
-              workerError(`Cannot find ${monitor.parent} in scraper data...`, user);
+              workerError(`Cannot find ${monitor.parent} in scraper data...`, currentUser);
               return;
             }
             if (verify(parseFloat(scraperItem.data), monitor.condition, parseFloat(monitor.threshold))) {
-              const notifierType = await getNotifierType(monitor, user);
+              const notifierType = await getNotifierType(monitor, currentUser);
               if (!notifierType) {
                 return;
               }
-              workerInfo(`Sending notification: ${monitor.parent} over threshold!`, user);
+              workerInfo(`Sending notification: ${monitor.parent} over threshold!`, currentUser);
               const matchedNotifiers = NotifierCatalog.getSupportedNotifiers()
                 .keys()
                 .filter((notifier) => notifierType === notifier);
@@ -308,38 +325,38 @@ async function checkData(user) {
                   try {
                     const notifyUrl = RequestUtils.buildUrl(`${SERVER_ADDRESS}/api/notifier`, {
                       type: notifier,
-                      user: user.id,
+                      user: currentUser.id,
                     });
                     notifyResponse = await RequestUtils.fetchWithRetry(
                       notifyUrl,
                       {
                         method: "POST",
-                        headers: { Authorization: `Bearer ${user.jwt}` },
+                        headers: { Authorization: `Bearer ${currentUser.jwt}` },
                         body: JSON.stringify({
                           name: monitor.parent,
-                          receiver: user.email,
+                          receiver: currentUser.email,
                           avatar: scraperItem.icon,
                           details: { message, data: scraperItem.data, threshold: monitor.threshold },
                         }),
                       },
                     );
                   } catch (error) {
-                    workerError(`Notification error: ${error.message}`, user);
+                    workerError(`Notification error: ${error.message}`, currentUser);
                     return;
                   }
                   if (!notifyResponse.ok) {
-                    workerError(`Notification error: ${await notifyResponse.json()}`, user);
+                    workerError(`Notification error: ${await notifyResponse.json()}`, currentUser);
                     return;
                   }
-                  updateSendTimestamp(user, monitor.parent);
-                  workerInfo(`Notification ok: ${await notifyResponse.json()}`, user);
+                  updateSendTimestamp(currentUser, monitor.parent);
+                  workerInfo(`Notification ok: ${await notifyResponse.json()}`, currentUser);
                 }),
               );
             } else {
-              workerInfo(`Skipping ${monitor.parent}: Threshold value was not met.`, user);
+              workerInfo(`Skipping ${monitor.parent}: Threshold value was not met.`, currentUser);
             }
           } catch (error) {
-            workerError(error.message, user);
+            workerError(error.message, currentUser);
           }
         }),
       );

--- a/src/lib/DataWorker.js
+++ b/src/lib/DataWorker.js
@@ -80,6 +80,30 @@ function workerError(message, user = null) {
 }
 
 /**
+ * Method used to extract human-readable response message from fetch response
+ * @param {Response} response Response object returned by fetch
+ * @returns parsed response message string
+ */
+async function getResponseMessage(response) {
+  try {
+    const payload = await response.json();
+    if (typeof payload === "string") {
+      return payload;
+    }
+    if (payload?.message) {
+      return String(payload.message);
+    }
+    return JSON.stringify(payload);
+  } catch {
+    try {
+      return await response.text();
+    } catch {
+      return "No response details available.";
+    }
+  }
+}
+
+/**
  * Method used to verify two input values against each other
  * @param {Number} val1 First value to be verified
  * @param {String} operator The operator used to verify both values
@@ -345,11 +369,11 @@ async function checkData(user) {
                     return;
                   }
                   if (!notifyResponse.ok) {
-                    workerError(`Notification error: ${await notifyResponse.json()}`, currentUser);
+                    workerError(`Notification error: ${await getResponseMessage(notifyResponse)}`, currentUser);
                     return;
                   }
                   updateSendTimestamp(currentUser, monitor.parent);
-                  workerInfo(`Notification ok: ${await notifyResponse.json()}`, currentUser);
+                  workerInfo(`Notification ok: ${await getResponseMessage(notifyResponse)}`, currentUser);
                 }),
               );
             } else {

--- a/src/lib/DataWorker.js
+++ b/src/lib/DataWorker.js
@@ -80,30 +80,6 @@ function workerError(message, user = null) {
 }
 
 /**
- * Method used to extract human-readable response message from fetch response
- * @param {Response} response Response object returned by fetch
- * @returns parsed response message string
- */
-async function getResponseMessage(response) {
-  try {
-    const payload = await response.json();
-    if (typeof payload === "string") {
-      return payload;
-    }
-    if (payload?.message) {
-      return String(payload.message);
-    }
-    return JSON.stringify(payload);
-  } catch {
-    try {
-      return await response.text();
-    } catch {
-      return "No response details available.";
-    }
-  }
-}
-
-/**
  * Method used to verify two input values against each other
  * @param {Number} val1 First value to be verified
  * @param {String} operator The operator used to verify both values
@@ -369,11 +345,14 @@ async function checkData(user) {
                     return;
                   }
                   if (!notifyResponse.ok) {
-                    workerError(`Notification error: ${await getResponseMessage(notifyResponse)}`, currentUser);
+                    workerError(
+                      `Notification error: ${await RequestUtils.getResponseMessage(notifyResponse)}`,
+                      currentUser,
+                    );
                     return;
                   }
                   updateSendTimestamp(currentUser, monitor.parent);
-                  workerInfo(`Notification ok: ${await getResponseMessage(notifyResponse)}`, currentUser);
+                  workerInfo(`Notification ok: ${await RequestUtils.getResponseMessage(notifyResponse)}`, currentUser);
                 }),
               );
             } else {

--- a/src/lib/RequestUtils.js
+++ b/src/lib/RequestUtils.js
@@ -38,20 +38,24 @@ export class RequestUtils {
    */
   static async getResponseMessage(response) {
     try {
-      const payload = await response.json();
-      if (typeof payload === "string") {
-        return payload;
+      const rawBody = await response.text();
+      if (rawBody == null || rawBody === "") {
+        return "";
       }
-      if (payload?.message) {
-        return String(payload.message);
-      }
-      return JSON.stringify(payload);
-    } catch {
       try {
-        return await response.text();
+        const payload = JSON.parse(rawBody);
+        if (typeof payload === "string") {
+          return payload;
+        }
+        if (payload?.message != null) {
+          return String(payload.message);
+        }
+        return JSON.stringify(payload);
       } catch {
-        return "No response details available.";
+        return rawBody;
       }
+    } catch {
+      return "No response details available.";
     }
   }
 

--- a/src/lib/RequestUtils.js
+++ b/src/lib/RequestUtils.js
@@ -32,6 +32,30 @@ export class RequestUtils {
   }
 
   /**
+   * Method used to extract human-readable response message from fetch response
+   * @param {Response} response Response object returned by fetch
+   * @returns parsed response message string
+   */
+  static async getResponseMessage(response) {
+    try {
+      const payload = await response.json();
+      if (typeof payload === "string") {
+        return payload;
+      }
+      if (payload?.message) {
+        return String(payload.message);
+      }
+      return JSON.stringify(payload);
+    } catch {
+      try {
+        return await response.text();
+      } catch {
+        return "No response details available.";
+      }
+    }
+  }
+
+  /**
    * Method used to convert input value to number with fallback
    * @param {unknown} value Input value to be converted
    * @param {Number} fallback Number used when input cannot be converted

--- a/src/lib/ScraperRequest.js
+++ b/src/lib/ScraperRequest.js
@@ -1,4 +1,5 @@
 import { AppConfig } from "@/config/AppConfig";
+import { RequestUtils } from "@/lib/RequestUtils";
 
 export class ScraperRequest {
   static #config = AppConfig.getConfig();
@@ -60,11 +61,7 @@ export class ScraperRequest {
       if (response.ok) {
         return JSON.stringify(await response.json());
       }
-      const textResponse = await response.text();
-      if (textResponse.startsWith('"') && textResponse.endsWith('"')) {
-        return textResponse.substring(1, textResponse.length - 1);
-      }
-      return textResponse;
+      return await RequestUtils.getResponseMessage(response);
     }
     return await response.text();
   }

--- a/src/views/HomePage.jsx
+++ b/src/views/HomePage.jsx
@@ -4,6 +4,7 @@ import { useContext, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "react-toastify";
 import { LoginContext } from "@/context/Contexts";
+import { RequestUtils } from "@/lib/RequestUtils";
 
 export default function HomePage({ demoEnabled, initError }) {
   const [email, setEmail] = useState("");
@@ -19,10 +20,10 @@ export default function HomePage({ demoEnabled, initError }) {
 
   const userSave = async (userData) => {
     const getUserResponse = await fetch(`/api/user?email=${userData.email}`);
-    const getUserData = await getUserResponse.json();
     if (!getUserResponse.ok) {
-      return { id: undefined, message: getUserData.message };
+      return { id: undefined, message: await RequestUtils.getResponseMessage(getUserResponse) };
     }
+    const getUserData = await getUserResponse.json();
     if (getUserData.length > 1) {
       return { id: undefined, message: "Error: Received multiple user entries." };
     }
@@ -33,10 +34,10 @@ export default function HomePage({ demoEnabled, initError }) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(userData),
     });
-    const addUserData = await addUserResponse.json();
     if (!addUserResponse.ok) {
-      return { id: undefined, message: addUserData.message };
+      return { id: undefined, message: await RequestUtils.getResponseMessage(addUserResponse) };
     }
+    const addUserData = await addUserResponse.json();
     return { id: addUserData.id, message: `User ${userData.email} saved.` };
   };
 
@@ -49,7 +50,7 @@ export default function HomePage({ demoEnabled, initError }) {
       });
       if (!response.ok) {
         logout();
-        toast.error(await response.text());
+        toast.error(await RequestUtils.getResponseMessage(response));
         return;
       }
       const shouldProceed = await action(await response.json());

--- a/src/views/NotifiersPage.jsx
+++ b/src/views/NotifiersPage.jsx
@@ -37,11 +37,11 @@ const NotifiersPage = () => {
       }
       const notifiersUrl = RequestUtils.buildUrl("/api/notifier", { user });
       const notifiersResponse = await fetch(notifiersUrl, { headers: getAuthHeaders() });
-      const notifiersData = await notifiersResponse.json();
       if (!notifiersResponse.ok) {
-        toast.error(notifiersData.message);
+        toast.error(await RequestUtils.getResponseMessage(notifiersResponse));
         return;
       }
+      const notifiersData = await notifiersResponse.json();
       setNotifiers(notifiersData);
       setAddDisabled(notifiersData.length === TOTAL_NOTIFIERS_NO);
     } catch (error) {

--- a/tests/app/api/init/route.test.js
+++ b/tests/app/api/init/route.test.js
@@ -17,7 +17,7 @@ jest.mock("@/lib/ScraperRequest", () => ({
   ScraperRequest: { GET: jest.fn() },
 }));
 jest.mock("@/lib/RequestUtils", () => ({
-  RequestUtils: { getErrorStatus: jest.fn() },
+  RequestUtils: { getErrorStatus: jest.fn(), getResponseMessage: jest.fn() },
 }));
 jest.mock("@/model/MonitorService", () => ({
   MonitorService: { initializeTable: jest.fn() },
@@ -64,6 +64,7 @@ describe("app/api/init route", () => {
     MonitorService.initializeTable.mockResolvedValue({ result: true });
     UserService.migrateSensitiveData.mockResolvedValue(1);
     NotifierService.migrateSensitiveData.mockResolvedValue(2);
+    RequestUtils.getResponseMessage.mockResolvedValue("features down");
   });
 
   test("returns initialized features payload on success", async () => {
@@ -119,6 +120,7 @@ describe("app/api/init route", () => {
 
     expect(response.status).toBe(502);
     expect(body).toEqual({ init: false, message: "features down" });
+    expect(RequestUtils.getResponseMessage).toHaveBeenCalledTimes(1);
   });
 
   test("returns mapped error status on thrown exception", async () => {

--- a/tests/components/DataMonitor.test.jsx
+++ b/tests/components/DataMonitor.test.jsx
@@ -304,7 +304,7 @@ describe("DataMonitor", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, type: "email" }] })
       .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 21, enabled: true, notifier_id: 2 }] })
       .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, type: "email" }] })
-      .mockResolvedValueOnce({ ok: false, json: async () => "send failed" });
+      .mockResolvedValueOnce({ ok: false, text: async () => '"send failed"' });
 
     renderWithLogin({ isDemo: false, userId: () => 7, email: "u@test.com", token: "jwt" });
 
@@ -324,7 +324,7 @@ describe("DataMonitor", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, type: "email" }] })
       .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 21, enabled: true, notifier_id: 2 }] })
       .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, type: "email" }] })
-      .mockResolvedValueOnce({ ok: true, json: async () => "ok" });
+      .mockResolvedValueOnce({ ok: true, text: async () => '"ok"' });
 
     renderWithLogin({ isDemo: false, userId: () => 7, email: "u@test.com", token: "jwt" });
 

--- a/tests/components/NotifierCard.test.jsx
+++ b/tests/components/NotifierCard.test.jsx
@@ -118,7 +118,7 @@ describe("NotifierCard", () => {
   });
 
   test("shows API error message when save fails", async () => {
-    global.fetch.mockResolvedValueOnce({ ok: false, json: async () => ({ message: "save failed" }) });
+    global.fetch.mockResolvedValueOnce({ ok: false, text: async () => '{"message":"save failed"}' });
 
     render(
       <NotifierCard
@@ -165,7 +165,7 @@ describe("NotifierCard", () => {
   });
 
   test("shows API error message when delete fails", async () => {
-    global.fetch.mockResolvedValueOnce({ ok: false, json: async () => ({ message: "delete failed" }) });
+    global.fetch.mockResolvedValueOnce({ ok: false, text: async () => '{"message":"delete failed"}' });
 
     render(
       <NotifierCard

--- a/tests/lib/RequestUtils.test.js
+++ b/tests/lib/RequestUtils.test.js
@@ -162,4 +162,70 @@ describe("RequestUtils", () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
     expect(response.status).toBe(503);
   });
+
+  test("getResponseMessage returns JSON string payload", async () => {
+    const response = {
+      json: jest.fn(async () => "plain message"),
+      text: jest.fn(async () => "unused"),
+    };
+
+    const message = await RequestUtils.getResponseMessage(response);
+
+    expect(message).toBe("plain message");
+    expect(response.text).not.toHaveBeenCalled();
+  });
+
+  test("getResponseMessage returns message field from JSON payload", async () => {
+    const response = {
+      json: jest.fn(async () => ({ message: "bad request" })),
+      text: jest.fn(async () => "unused"),
+    };
+
+    const message = await RequestUtils.getResponseMessage(response);
+
+    expect(message).toBe("bad request");
+    expect(response.text).not.toHaveBeenCalled();
+  });
+
+  test("getResponseMessage stringifies JSON payload without message field", async () => {
+    const response = {
+      json: jest.fn(async () => ({ error: "boom", code: 123 })),
+      text: jest.fn(async () => "unused"),
+    };
+
+    const message = await RequestUtils.getResponseMessage(response);
+
+    expect(message).toBe('{"error":"boom","code":123}');
+    expect(response.text).not.toHaveBeenCalled();
+  });
+
+  test("getResponseMessage falls back to text when JSON parsing fails", async () => {
+    const response = {
+      json: jest.fn(async () => {
+        throw new Error("invalid json");
+      }),
+      text: jest.fn(async () => "service unavailable"),
+    };
+
+    const message = await RequestUtils.getResponseMessage(response);
+
+    expect(message).toBe("service unavailable");
+    expect(response.text).toHaveBeenCalledTimes(1);
+  });
+
+  test("getResponseMessage returns default fallback when JSON and text parsing fail", async () => {
+    const response = {
+      json: jest.fn(async () => {
+        throw new Error("invalid json");
+      }),
+      text: jest.fn(async () => {
+        throw new Error("text stream failed");
+      }),
+    };
+
+    const message = await RequestUtils.getResponseMessage(response);
+
+    expect(message).toBe("No response details available.");
+    expect(response.text).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/lib/RequestUtils.test.js
+++ b/tests/lib/RequestUtils.test.js
@@ -165,45 +165,39 @@ describe("RequestUtils", () => {
 
   test("getResponseMessage returns JSON string payload", async () => {
     const response = {
-      json: jest.fn(async () => "plain message"),
-      text: jest.fn(async () => "unused"),
+      text: jest.fn(async () => '"plain message"'),
     };
 
     const message = await RequestUtils.getResponseMessage(response);
 
     expect(message).toBe("plain message");
-    expect(response.text).not.toHaveBeenCalled();
+    expect(response.text).toHaveBeenCalledTimes(1);
   });
 
   test("getResponseMessage returns message field from JSON payload", async () => {
     const response = {
-      json: jest.fn(async () => ({ message: "bad request" })),
-      text: jest.fn(async () => "unused"),
+      text: jest.fn(async () => '{"message":"bad request"}'),
     };
 
     const message = await RequestUtils.getResponseMessage(response);
 
     expect(message).toBe("bad request");
-    expect(response.text).not.toHaveBeenCalled();
+    expect(response.text).toHaveBeenCalledTimes(1);
   });
 
   test("getResponseMessage stringifies JSON payload without message field", async () => {
     const response = {
-      json: jest.fn(async () => ({ error: "boom", code: 123 })),
-      text: jest.fn(async () => "unused"),
+      text: jest.fn(async () => '{"error":"boom","code":123}'),
     };
 
     const message = await RequestUtils.getResponseMessage(response);
 
     expect(message).toBe('{"error":"boom","code":123}');
-    expect(response.text).not.toHaveBeenCalled();
+    expect(response.text).toHaveBeenCalledTimes(1);
   });
 
-  test("getResponseMessage falls back to text when JSON parsing fails", async () => {
+  test("getResponseMessage returns raw text when JSON parsing fails", async () => {
     const response = {
-      json: jest.fn(async () => {
-        throw new Error("invalid json");
-      }),
       text: jest.fn(async () => "service unavailable"),
     };
 
@@ -213,11 +207,19 @@ describe("RequestUtils", () => {
     expect(response.text).toHaveBeenCalledTimes(1);
   });
 
-  test("getResponseMessage returns default fallback when JSON and text parsing fail", async () => {
+  test("getResponseMessage returns empty string for empty response body", async () => {
     const response = {
-      json: jest.fn(async () => {
-        throw new Error("invalid json");
-      }),
+      text: jest.fn(async () => ""),
+    };
+
+    const message = await RequestUtils.getResponseMessage(response);
+
+    expect(message).toBe("");
+    expect(response.text).toHaveBeenCalledTimes(1);
+  });
+
+  test("getResponseMessage returns default fallback when text parsing fails", async () => {
+    const response = {
       text: jest.fn(async () => {
         throw new Error("text stream failed");
       }),

--- a/tests/views/HomePage.test.jsx
+++ b/tests/views/HomePage.test.jsx
@@ -154,7 +154,7 @@ describe("HomePage", () => {
       })
       .mockResolvedValueOnce({
         ok: false,
-        json: async () => ({ message: "create failed" }),
+        text: async () => '{"message":"create failed"}',
       });
 
     renderWithContext({ demo: jest.fn(), login: loginMock, logout: jest.fn() });
@@ -188,7 +188,7 @@ describe("HomePage", () => {
       })
       .mockResolvedValueOnce({
         ok: false,
-        json: async () => ({ message: "update failed" }),
+        text: async () => '{"message":"update failed"}',
       });
 
     renderWithContext({ demo: jest.fn(), login: loginMock, logout: jest.fn() });
@@ -218,7 +218,7 @@ describe("HomePage", () => {
       })
       .mockResolvedValueOnce({
         ok: false,
-        json: async () => ({ message: "lookup failed" }),
+        text: async () => '{"message":"lookup failed"}',
       });
 
     renderWithContext({ demo: jest.fn(), login: loginMock, logout: jest.fn() });

--- a/tests/views/NotifiersPage.test.jsx
+++ b/tests/views/NotifiersPage.test.jsx
@@ -114,7 +114,7 @@ describe("NotifiersPage", () => {
   test("shows API message when notifier fetch returns a non-ok response", async () => {
     global.fetch.mockResolvedValueOnce({
       ok: false,
-      json: async () => ({ message: "notifiers unavailable" }),
+      text: async () => '{"message":"notifiers unavailable"}',
     });
 
     renderWithLogin({ userIdValue: 4, token: "token-4" });


### PR DESCRIPTION
This patch fixes #94 
Now in every worker check user data (JWT) is checked to have the newest possible value and to fix the 403 response after login action in UI. Also non-informative `[object Object]` in error message was fixed, unit tests were adjusted and new cases were added.