### PR TITLE
Enhanced data sanitizer usage

### DIFF
--- a/src/app/api/monitor/route.js
+++ b/src/app/api/monitor/route.js
@@ -11,7 +11,7 @@ import { RequestUtils } from "@/lib/RequestUtils";
  * @returns sanitized monitor text value
  */
 function sanitizeMonitorText(value, maxLength) {
-  return DataSanitizer.sanitizeTextForLog(typeof value === "string" ? value : "", maxLength);
+  return DataSanitizer.sanitizeText(typeof value === "string" ? value : "", maxLength);
 }
 
 /**

--- a/src/app/api/monitor/route.js
+++ b/src/app/api/monitor/route.js
@@ -1,7 +1,58 @@
 import { MonitorService } from "@/model/MonitorService";
 import { NotifierService } from "@/model/NotifierService";
 import { authorizeUser } from "@/lib/ApiUserAuth";
+import { DataSanitizer } from "@/lib/DataSanitizer";
 import { RequestUtils } from "@/lib/RequestUtils";
+
+/**
+ * Method used to sanitize monitor text input values at API boundary
+ * @param {unknown} value Raw monitor text value
+ * @param {Number} maxLength Maximum output length
+ * @returns sanitized monitor text value
+ */
+function sanitizeMonitorText(value, maxLength) {
+  return DataSanitizer.sanitizeTextForLog(typeof value === "string" ? value : "", maxLength);
+}
+
+/**
+ * Method used to normalize query filter values before querying monitor data
+ * @param {URLSearchParams} searchParams Query parameters object
+ * @returns normalized monitor filters object
+ */
+function normalizeMonitorFilters(searchParams) {
+  const id = searchParams.get("id");
+  const parent = sanitizeMonitorText(searchParams.get("parent"), 256);
+  const enabled = searchParams.get("enabled");
+  const threshold = searchParams.get("threshold");
+  const condition = sanitizeMonitorText(searchParams.get("condition"), 8);
+  const notifier = searchParams.get("notifier");
+  const interval = searchParams.get("interval");
+  return {
+    ...(id && { id }),
+    ...(parent && { parent }),
+    ...(enabled && { enabled }),
+    ...(threshold && { threshold }),
+    ...(condition && { condition }),
+    ...(notifier && { notifier }),
+    ...(interval && { interval }),
+  };
+}
+
+/**
+ * Method used to normalize monitor payload text fields before save/update operations
+ * @param {Object} monitorData Input monitor payload
+ * @returns normalized monitor payload
+ */
+function normalizeMonitorInput(monitorData) {
+  if (monitorData == null) {
+    return monitorData;
+  }
+  return {
+    ...monitorData,
+    ...(monitorData.parent != null && { parent: sanitizeMonitorText(monitorData.parent, 256) }),
+    ...(monitorData.condition != null && { condition: sanitizeMonitorText(monitorData.condition, 8) }),
+  };
+}
 
 /**
  * Method used to validate notifier ownership for monitor operations
@@ -36,21 +87,8 @@ export async function GET(request) {
     const searchParams = request.nextUrl.searchParams;
     const user = searchParams.get("user");
     const authorizedUserId = await authorizeUser(request, user);
-    const id = searchParams.get("id");
-    const parent = searchParams.get("parent");
-    const enabled = searchParams.get("enabled");
-    const threshold = searchParams.get("threshold");
-    const condition = searchParams.get("condition");
-    const notifier = searchParams.get("notifier");
-    const interval = searchParams.get("interval");
     const monitors = await MonitorService.filterMonitors({
-      ...(id && { id }),
-      ...(parent && { parent }),
-      ...(enabled && { enabled }),
-      ...(threshold && { threshold }),
-      ...(condition && { condition }),
-      ...(notifier && { notifier }),
-      ...(interval && { interval }),
+      ...normalizeMonitorFilters(searchParams),
       user: authorizedUserId,
     });
     return new Response(JSON.stringify(monitors), {
@@ -73,7 +111,7 @@ export async function GET(request) {
  */
 export async function POST(request) {
   try {
-    const monitorData = await request.json();
+    const monitorData = normalizeMonitorInput(await request.json());
     const authorizedUserId = await authorizeUser(request, monitorData.user);
     await assertNotifierOwnership(authorizedUserId, monitorData.notifier);
     const monitor = await MonitorService.addMonitor({
@@ -104,7 +142,7 @@ export async function PUT(request) {
     const id = searchParams.get("id");
     const user = searchParams.get("user");
     const authorizedUserId = await authorizeUser(request, user);
-    const monitorData = await request.json();
+    const monitorData = normalizeMonitorInput(await request.json());
     await assertNotifierOwnership(authorizedUserId, monitorData.notifier);
     const monitor = await MonitorService.editMonitorForUser(id, authorizedUserId, monitorData);
     if (monitor == null) {

--- a/src/app/api/monitor/route.js
+++ b/src/app/api/monitor/route.js
@@ -1,8 +1,11 @@
+import { Monitor } from "@/model/Monitor";
 import { MonitorService } from "@/model/MonitorService";
 import { NotifierService } from "@/model/NotifierService";
 import { authorizeUser } from "@/lib/ApiUserAuth";
 import { DataSanitizer } from "@/lib/DataSanitizer";
 import { RequestUtils } from "@/lib/RequestUtils";
+
+const SUPPORTED_CONDITIONS = new Set(Monitor.CONDITIONS.map((condition) => condition.value));
 
 /**
  * Method used to sanitize monitor text input values at API boundary
@@ -15,6 +18,16 @@ function sanitizeMonitorText(value, maxLength) {
 }
 
 /**
+ * Method used to normalize monitor condition values
+ * @param {unknown} value Raw monitor condition
+ * @returns sanitized condition when valid, empty string otherwise
+ */
+function sanitizeMonitorCondition(value) {
+  const sanitized = sanitizeMonitorText(value, 8);
+  return SUPPORTED_CONDITIONS.has(sanitized) ? sanitized : "";
+}
+
+/**
  * Method used to normalize query filter values before querying monitor data
  * @param {URLSearchParams} searchParams Query parameters object
  * @returns normalized monitor filters object
@@ -24,7 +37,7 @@ function normalizeMonitorFilters(searchParams) {
   const parent = sanitizeMonitorText(searchParams.get("parent"), 256);
   const enabled = searchParams.get("enabled");
   const threshold = searchParams.get("threshold");
-  const condition = sanitizeMonitorText(searchParams.get("condition"), 8);
+  const condition = sanitizeMonitorCondition(searchParams.get("condition"));
   const notifier = searchParams.get("notifier");
   const interval = searchParams.get("interval");
   return {
@@ -47,11 +60,26 @@ function normalizeMonitorInput(monitorData) {
   if (monitorData == null) {
     return monitorData;
   }
-  return {
-    ...monitorData,
-    ...(monitorData.parent != null && { parent: sanitizeMonitorText(monitorData.parent, 256) }),
-    ...(monitorData.condition != null && { condition: sanitizeMonitorText(monitorData.condition, 8) }),
-  };
+  const normalized = { ...monitorData };
+  if (monitorData.parent != null) {
+    const sanitizedParent = sanitizeMonitorText(monitorData.parent, 256);
+    if (!sanitizedParent) {
+      const error = new Error("Invalid monitor parent.");
+      error.status = 400;
+      throw error;
+    }
+    normalized.parent = sanitizedParent;
+  }
+  if (monitorData.condition != null) {
+    const sanitizedCondition = sanitizeMonitorCondition(monitorData.condition);
+    if (!sanitizedCondition) {
+      const error = new Error("Invalid monitor condition.");
+      error.status = 400;
+      throw error;
+    }
+    normalized.condition = sanitizedCondition;
+  }
+  return normalized;
 }
 
 /**

--- a/src/app/api/notifier/route.js
+++ b/src/app/api/notifier/route.js
@@ -28,6 +28,27 @@ function sanitizeNotifierText(value, maxLength) {
 }
 
 /**
+ * Method used to validate sensitive notifier credential fields without mutating value
+ * @param {unknown} value Raw sensitive input
+ * @param {String} fieldName Sensitive field name
+ * @returns validated sensitive value
+ */
+function validateNotifierCredential(value, fieldName) {
+  if (value == null) {
+    return "";
+  }
+  const input = String(value);
+  const hasDisallowedChars =
+    /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/.test(input);
+  if (hasDisallowedChars) {
+    const error = new Error(`Invalid ${fieldName}: contains disallowed control characters.`);
+    error.status = 400;
+    throw error;
+  }
+  return input;
+}
+
+/**
  * Method used to normalize notifier GET query filters
  * @param {URLSearchParams} searchParams Query parameters object
  * @returns normalized notifier filter object
@@ -35,9 +56,9 @@ function sanitizeNotifierText(value, maxLength) {
 function normalizeNotifierFilters(searchParams) {
   const id = searchParams.get("id");
   const type = sanitizeNotifierText(searchParams.get("type"), 64);
-  const origin = sanitizeNotifierText(searchParams.get("origin"), 512);
+  const origin = searchParams.get("origin");
   const sender = sanitizeNotifierText(searchParams.get("sender"), 256);
-  const password = sanitizeNotifierText(searchParams.get("password"), 512);
+  const password = searchParams.get("password");
   return {
     ...(id && { id }),
     ...(type && { type }),
@@ -62,8 +83,8 @@ function normalizeNotifierInput(notifier) {
     ...notifier,
     ...(notifier.type != null && { type: sanitizeNotifierText(notifier.type, 64) }),
     ...(notifier.sender != null && { sender: sanitizeNotifierText(notifier.sender, 256) }),
-    origin: sanitizeNotifierText(normalizedOrigin, 512),
-    password: sanitizeNotifierText(normalizedPassword, 512),
+    origin: validateNotifierCredential(normalizedOrigin, "notifier origin"),
+    password: validateNotifierCredential(normalizedPassword, "notifier password"),
   };
 }
 

--- a/src/app/api/notifier/route.js
+++ b/src/app/api/notifier/route.js
@@ -24,7 +24,7 @@ function normalizeSensitiveInput(value) {
  * @returns sanitized single-line text value
  */
 function sanitizeNotifierText(value, maxLength) {
-  return DataSanitizer.sanitizeTextForLog(typeof value === "string" ? value : "", maxLength);
+  return DataSanitizer.sanitizeText(typeof value === "string" ? value : "", maxLength);
 }
 
 /**

--- a/src/app/api/notifier/route.js
+++ b/src/app/api/notifier/route.js
@@ -39,7 +39,7 @@ function validateNotifierCredential(value, fieldName) {
   }
   const input = String(value);
   const hasDisallowedChars =
-    /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/.test(input);
+    /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u2028\u2029\u202A-\u202E\u2060-\u206F\uFEFF]/.test(input);
   if (hasDisallowedChars) {
     const error = new Error(`Invalid ${fieldName}: contains disallowed control characters.`);
     error.status = 400;

--- a/src/app/api/notifier/route.js
+++ b/src/app/api/notifier/route.js
@@ -79,18 +79,42 @@ function normalizeNotifierInput(notifier, options = {}) {
   if (notifier == null) {
     return notifier;
   }
+  const requireType = options.requireType === true;
+  const sanitizedType = notifier.type != null ? sanitizeNotifierText(notifier.type, 64) : "";
+  if (requireType === true && !sanitizedType) {
+    const error = new Error("Notifier type is required.");
+    error.status = 400;
+    throw error;
+  }
+  if (notifier.type != null && !sanitizedType) {
+    const error = new Error("Invalid notifier type.");
+    error.status = 400;
+    throw error;
+  }
+  const requireSender = options.requireSender === true;
+  const sanitizedSender = notifier.sender != null ? sanitizeNotifierText(notifier.sender, 256) : "";
+  if (requireSender === true && !sanitizedSender) {
+    const error = new Error("Notifier sender is required.");
+    error.status = 400;
+    throw error;
+  }
+  if (notifier.sender != null && !sanitizedSender) {
+    const error = new Error("Invalid notifier sender.");
+    error.status = 400;
+    throw error;
+  }
   const requireOrigin = options.requireOrigin === true;
   const normalizedOrigin = normalizeSensitiveInput(notifier.origin);
-  const normalizedPassword = normalizeSensitiveInput(notifier.password);
   if (requireOrigin && (normalizedOrigin == null || String(normalizedOrigin) === "")) {
     const error = new Error("Notifier origin is required.");
     error.status = 400;
     throw error;
   }
+  const normalizedPassword = normalizeSensitiveInput(notifier.password);
   return {
     ...notifier,
-    ...(notifier.type != null && { type: sanitizeNotifierText(notifier.type, 64) }),
-    ...(notifier.sender != null && { sender: sanitizeNotifierText(notifier.sender, 256) }),
+    ...(notifier.type != null && { type: sanitizedType }),
+    ...(notifier.sender != null && { sender: sanitizedSender }),
     origin: validateNotifierCredential(normalizedOrigin, "notifier origin"),
     password: validateNotifierCredential(normalizedPassword, "notifier password"),
   };
@@ -199,7 +223,11 @@ export async function POST(request) {
       });
     }
     // no 'type' parameter provider hence we want to create new notifier
-    const input = normalizeNotifierInput(await request.json(), { requireOrigin: true });
+    const input = normalizeNotifierInput(await request.json(), {
+      requireType: true,
+      requireSender: true,
+      requireOrigin: true,
+    });
     const authorizedUserId = await authorizeUser(request, input.user);
     const notifier = await NotifierService.addNotifier({
       ...input,

--- a/src/app/api/notifier/route.js
+++ b/src/app/api/notifier/route.js
@@ -1,5 +1,6 @@
 import { NotifierService } from "@/model/NotifierService";
 import { authorizeUser } from "@/lib/ApiUserAuth";
+import { DataSanitizer } from "@/lib/DataSanitizer";
 import { RequestUtils } from "@/lib/RequestUtils";
 import { NotifierCatalog } from "@/notifiers/core/NotifierCatalog";
 import { NotifierRegistry } from "@/notifiers/core/NotifierRegistry";
@@ -17,6 +18,36 @@ function normalizeSensitiveInput(value) {
 }
 
 /**
+ * Method used to sanitize notifier text fields at API boundary
+ * @param {unknown} value Raw text input
+ * @param {Number} maxLength Maximum output length
+ * @returns sanitized single-line text value
+ */
+function sanitizeNotifierText(value, maxLength) {
+  return DataSanitizer.sanitizeTextForLog(typeof value === "string" ? value : "", maxLength);
+}
+
+/**
+ * Method used to normalize notifier GET query filters
+ * @param {URLSearchParams} searchParams Query parameters object
+ * @returns normalized notifier filter object
+ */
+function normalizeNotifierFilters(searchParams) {
+  const id = searchParams.get("id");
+  const type = sanitizeNotifierText(searchParams.get("type"), 64);
+  const origin = sanitizeNotifierText(searchParams.get("origin"), 512);
+  const sender = sanitizeNotifierText(searchParams.get("sender"), 256);
+  const password = sanitizeNotifierText(searchParams.get("password"), 512);
+  return {
+    ...(id && { id }),
+    ...(type && { type }),
+    ...(origin && { origin }),
+    ...(sender && { sender }),
+    ...(password && { password }),
+  };
+}
+
+/**
  * Method used to normalize incoming notifier payload before save/update operations
  * @param {Object} notifier Input notifier payload from request body
  * @returns normalized notifier payload
@@ -25,10 +56,14 @@ function normalizeNotifierInput(notifier) {
   if (notifier == null) {
     return notifier;
   }
+  const normalizedOrigin = normalizeSensitiveInput(notifier.origin);
+  const normalizedPassword = normalizeSensitiveInput(notifier.password);
   return {
     ...notifier,
-    origin: normalizeSensitiveInput(notifier.origin),
-    password: normalizeSensitiveInput(notifier.password),
+    ...(notifier.type != null && { type: sanitizeNotifierText(notifier.type, 64) }),
+    ...(notifier.sender != null && { sender: sanitizeNotifierText(notifier.sender, 256) }),
+    origin: sanitizeNotifierText(normalizedOrigin, 512),
+    password: sanitizeNotifierText(normalizedPassword, 512),
   };
 }
 
@@ -94,17 +129,8 @@ export async function GET(request) {
     const searchParams = request.nextUrl.searchParams;
     const user = searchParams.get("user");
     const authorizedUserId = await authorizeUser(request, user);
-    const id = searchParams.get("id");
-    const type = searchParams.get("type");
-    const origin = searchParams.get("origin");
-    const sender = searchParams.get("sender");
-    const password = searchParams.get("password");
     const notifiers = await NotifierService.filterNotifiers({
-      ...(id && { id }),
-      ...(type && { type }),
-      ...(origin && { origin }),
-      ...(sender && { sender }),
-      ...(password && { password }),
+      ...normalizeNotifierFilters(searchParams),
       user: authorizedUserId,
     });
     return new Response(JSON.stringify(notifiers.map((notifier) => getSafeNotifier(notifier))), {
@@ -126,7 +152,7 @@ export async function GET(request) {
  * @returns Response object with JSON value containing notification sent result
  */
 export async function POST(request) {
-  const notifierType = request.nextUrl.searchParams.get("type");
+  const notifierType = sanitizeNotifierText(request.nextUrl.searchParams.get("type"), 64);
   try {
     const searchParams = request.nextUrl.searchParams;
     const userFromQuery = searchParams.get("user");

--- a/src/app/api/notifier/route.js
+++ b/src/app/api/notifier/route.js
@@ -71,14 +71,22 @@ function normalizeNotifierFilters(searchParams) {
 /**
  * Method used to normalize incoming notifier payload before save/update operations
  * @param {Object} notifier Input notifier payload from request body
+ * @param {Object} options Normalization behavior flags
+ * @param {Boolean} options.requireOrigin Indicates whether non-empty origin is required
  * @returns normalized notifier payload
  */
-function normalizeNotifierInput(notifier) {
+function normalizeNotifierInput(notifier, options = {}) {
   if (notifier == null) {
     return notifier;
   }
+  const requireOrigin = options.requireOrigin === true;
   const normalizedOrigin = normalizeSensitiveInput(notifier.origin);
   const normalizedPassword = normalizeSensitiveInput(notifier.password);
+  if (requireOrigin && (normalizedOrigin == null || String(normalizedOrigin) === "")) {
+    const error = new Error("Notifier origin is required.");
+    error.status = 400;
+    throw error;
+  }
   return {
     ...notifier,
     ...(notifier.type != null && { type: sanitizeNotifierText(notifier.type, 64) }),
@@ -191,7 +199,7 @@ export async function POST(request) {
       });
     }
     // no 'type' parameter provider hence we want to create new notifier
-    const input = normalizeNotifierInput(await request.json());
+    const input = normalizeNotifierInput(await request.json(), { requireOrigin: true });
     const authorizedUserId = await authorizeUser(request, input.user);
     const notifier = await NotifierService.addNotifier({
       ...input,
@@ -221,7 +229,7 @@ export async function PUT(request) {
     const id = searchParams.get("id");
     const user = searchParams.get("user");
     const authorizedUserId = await authorizeUser(request, user);
-    const notifierData = normalizeNotifierInput(await request.json());
+    const notifierData = normalizeNotifierInput(await request.json(), { requireOrigin: false });
     const notifier = await NotifierService.editNotifierForUser(id, authorizedUserId, notifierData);
     if (notifier == null) {
       const error = new Error("Notifier not found for provided user and id.");

--- a/src/app/api/notifier/route.js
+++ b/src/app/api/notifier/route.js
@@ -72,6 +72,8 @@ function normalizeNotifierFilters(searchParams) {
  * Method used to normalize incoming notifier payload before save/update operations
  * @param {Object} notifier Input notifier payload from request body
  * @param {Object} options Normalization behavior flags
+ * @param {Boolean} options.requireType Indicates whether non-empty type is required
+ * @param {Boolean} options.requireSender Indicates whether non-empty sender is required
  * @param {Boolean} options.requireOrigin Indicates whether non-empty origin is required
  * @returns normalized notifier payload
  */
@@ -81,7 +83,7 @@ function normalizeNotifierInput(notifier, options = {}) {
   }
   const requireType = options.requireType === true;
   const sanitizedType = notifier.type != null ? sanitizeNotifierText(notifier.type, 64) : "";
-  if (requireType === true && !sanitizedType) {
+  if (requireType && !sanitizedType) {
     const error = new Error("Notifier type is required.");
     error.status = 400;
     throw error;
@@ -93,7 +95,7 @@ function normalizeNotifierInput(notifier, options = {}) {
   }
   const requireSender = options.requireSender === true;
   const sanitizedSender = notifier.sender != null ? sanitizeNotifierText(notifier.sender, 256) : "";
-  if (requireSender === true && !sanitizedSender) {
+  if (requireSender && !sanitizedSender) {
     const error = new Error("Notifier sender is required.");
     error.status = 400;
     throw error;

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -53,14 +53,26 @@ function normalizeUserFilters(searchParams) {
  * @param {Object} user Input user payload from request body
  * @returns normalized user payload
  */
-function normalizeUserInput(user) {
+function normalizeUserInput(user, options = {}) {
   if (user == null) {
     return user;
   }
+  const requireJwt = options.requireJwt === true;
   const normalizedJwt = normalizeSensitiveInput(user.jwt);
+  const sanitizedJwt = sanitizeUserJwt(normalizedJwt);
+  if (requireJwt && !sanitizedJwt) {
+    const error = new Error("User JWT is required.");
+    error.status = 400;
+    throw error;
+  }
+  if (user.jwt != null && normalizedJwt !== "" && !sanitizedJwt) {
+    const error = new Error("Invalid user JWT.");
+    error.status = 400;
+    throw error;
+  }
   const normalized = {
     ...user,
-    jwt: sanitizeUserJwt(normalizedJwt),
+    jwt: sanitizedJwt,
   };
   if (user.email != null) {
     const sanitizedEmail = sanitizeUserEmail(user.email);
@@ -117,7 +129,7 @@ export async function GET(request) {
 
 export async function POST(request) {
   try {
-    const userData = normalizeUserInput(await request.json());
+    const userData = normalizeUserInput(await request.json(), { requireJwt: true });
     const user = await UserService.addUser(userData);
     return new Response(JSON.stringify(getSafeUser(user)), {
       status: 200,
@@ -136,7 +148,7 @@ export async function PUT(request) {
   try {
     const searchParams = request.nextUrl.searchParams;
     const id = searchParams.get("id");
-    const userData = normalizeUserInput(await request.json());
+    const userData = normalizeUserInput(await request.json(), { requireJwt: false });
     const user = await UserService.editUser(id, userData);
     return new Response(JSON.stringify(getSafeUser(user)), {
       status: 200,

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -58,11 +58,20 @@ function normalizeUserInput(user) {
     return user;
   }
   const normalizedJwt = normalizeSensitiveInput(user.jwt);
-  return {
+  const normalized = {
     ...user,
-    ...(user.email != null && { email: sanitizeUserEmail(user.email) }),
     jwt: sanitizeUserJwt(normalizedJwt),
   };
+  if (user.email != null) {
+    const sanitizedEmail = sanitizeUserEmail(user.email);
+    if (!sanitizedEmail) {
+      const error = new Error("Invalid user email.");
+      error.status = 400;
+      throw error;
+    }
+    normalized.email = sanitizedEmail;
+  }
+  return normalized;
 }
 
 /**

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -98,7 +98,7 @@ function normalizeUserInput(user, options = {}) {
   }
   return {
     ...user,
-    email: sanitizedEmail,
+    ...(user.email != null && { email: sanitizedEmail }),
     jwt: sanitizedJwt,
   };
 }

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -1,4 +1,5 @@
 import { UserService } from "@/model/UserService";
+import { DataSanitizer } from "@/lib/DataSanitizer";
 import { RequestUtils } from "@/lib/RequestUtils";
 
 const PRIVATE_PLACEHOLDER = "PRIVATE";
@@ -13,6 +14,40 @@ function normalizeSensitiveInput(value) {
 }
 
 /**
+ * Method used to sanitize user email values at API boundary
+ * @param {unknown} value Raw email input
+ * @returns sanitized email value when valid, empty string otherwise
+ */
+function sanitizeUserEmail(value) {
+  return DataSanitizer.sanitizeEmail(typeof value === "string" ? value : "");
+}
+
+/**
+ * Method used to sanitize user jwt values at API boundary
+ * @param {unknown} value Raw jwt input
+ * @returns single-line sanitized jwt string
+ */
+function sanitizeUserJwt(value) {
+  return DataSanitizer.sanitizeTextForLog(typeof value === "string" ? value : "", 2048);
+}
+
+/**
+ * Method used to normalize GET query filters for user route
+ * @param {URLSearchParams} searchParams User query parameters
+ * @returns normalized filter object
+ */
+function normalizeUserFilters(searchParams) {
+  const id = searchParams.get("id");
+  const email = sanitizeUserEmail(searchParams.get("email"));
+  const jwt = sanitizeUserJwt(searchParams.get("jwt"));
+  return {
+    ...(id && { id }),
+    ...(email && { email }),
+    ...(jwt && { jwt }),
+  };
+}
+
+/**
  * Method used to normalize incoming user payload before save/update operations
  * @param {Object} user Input user payload from request body
  * @returns normalized user payload
@@ -21,9 +56,11 @@ function normalizeUserInput(user) {
   if (user == null) {
     return user;
   }
+  const normalizedJwt = normalizeSensitiveInput(user.jwt);
   return {
     ...user,
-    jwt: normalizeSensitiveInput(user.jwt),
+    ...(user.email != null && { email: sanitizeUserEmail(user.email) }),
+    jwt: sanitizeUserJwt(normalizedJwt),
   };
 }
 
@@ -52,13 +89,8 @@ export async function GET(request) {
         headers: { "Content-Type": "application/json" },
       });
     }
-    const id = searchParams.get("id");
-    const email = searchParams.get("email");
-    const jwt = searchParams.get("jwt");
     const users = await UserService.filterUsers({
-      ...(id && { id }),
-      ...(email && { email }),
-      ...(jwt && { jwt }),
+      ...normalizeUserFilters(searchParams),
     });
     return new Response(JSON.stringify(users.map((user) => getSafeUser(user))), {
       status: 200,

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -28,7 +28,7 @@ function sanitizeUserEmail(value) {
  * @returns single-line sanitized jwt string
  */
 function sanitizeUserJwt(value) {
-  return DataSanitizer.sanitizeTextForLog(typeof value === "string" ? value : "", 2048);
+  return DataSanitizer.sanitizeText(typeof value === "string" ? value : "", 2048);
 }
 
 /**

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -40,10 +40,11 @@ function normalizeUserFilters(searchParams) {
   const id = searchParams.get("id");
   const email = sanitizeUserEmail(searchParams.get("email"));
   const jwt = sanitizeUserJwt(searchParams.get("jwt"));
+  const hasIndexedFilter = Boolean(id || email);
   return {
     ...(id && { id }),
     ...(email && { email }),
-    ...(jwt && { jwt }),
+    ...(hasIndexedFilter && jwt && { jwt }),
   };
 }
 

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -23,12 +23,23 @@ function sanitizeUserEmail(value) {
 }
 
 /**
- * Method used to sanitize user jwt values at API boundary
+ * Method used to validate user jwt values without mutating credential content
  * @param {unknown} value Raw jwt input
- * @returns single-line sanitized jwt string
+ * @returns validated jwt string
  */
-function sanitizeUserJwt(value) {
-  return DataSanitizer.sanitizeText(typeof value === "string" ? value : "", 2048);
+function validateUserJwt(value) {
+  if (value == null) {
+    return "";
+  }
+  const input = String(value);
+  const hasDisallowedChars =
+    /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u2028\u2029\u202A-\u202E\u2060-\u206F\uFEFF]/.test(input);
+  if (hasDisallowedChars) {
+    const error = new Error("Invalid user JWT: contains disallowed control characters.");
+    error.status = 400;
+    throw error;
+  }
+  return input;
 }
 
 /**
@@ -39,7 +50,7 @@ function sanitizeUserJwt(value) {
 function normalizeUserFilters(searchParams) {
   const id = searchParams.get("id");
   const email = sanitizeUserEmail(searchParams.get("email"));
-  const jwt = sanitizeUserJwt(searchParams.get("jwt"));
+  const jwt = validateUserJwt(searchParams.get("jwt"));
   const hasIndexedFilter = Boolean(id || email);
   return {
     ...(id && { id }),
@@ -51,6 +62,9 @@ function normalizeUserFilters(searchParams) {
 /**
  * Method used to normalize incoming user payload before save/update operations
  * @param {Object} user Input user payload from request body
+ * @param {Object} options Normalization behavior flags
+ * @param {Boolean} options.requireEmail Indicates whether non-empty email is required
+ * @param {Boolean} options.requireJwt Indicates whether non-empty jwt is required
  * @returns normalized user payload
  */
 function normalizeUserInput(user, options = {}) {
@@ -59,7 +73,7 @@ function normalizeUserInput(user, options = {}) {
   }
   const requireJwt = options.requireJwt === true;
   const normalizedJwt = normalizeSensitiveInput(user.jwt);
-  const sanitizedJwt = sanitizeUserJwt(normalizedJwt);
+  const sanitizedJwt = validateUserJwt(normalizedJwt);
   if (requireJwt && !sanitizedJwt) {
     const error = new Error("User JWT is required.");
     error.status = 400;
@@ -70,20 +84,23 @@ function normalizeUserInput(user, options = {}) {
     error.status = 400;
     throw error;
   }
-  const normalized = {
+  const requireEmail = options.requireEmail === true;
+  const sanitizedEmail = user.email != null ? sanitizeUserEmail(user.email) : "";
+  if (requireEmail && !sanitizedEmail) {
+    const error = new Error("User email is required.");
+    error.status = 400;
+    throw error;
+  }
+  if (user.email != null && !sanitizedEmail) {
+    const error = new Error("Invalid user email.");
+    error.status = 400;
+    throw error;
+  }
+  return {
     ...user,
+    email: sanitizedEmail,
     jwt: sanitizedJwt,
   };
-  if (user.email != null) {
-    const sanitizedEmail = sanitizeUserEmail(user.email);
-    if (!sanitizedEmail) {
-      const error = new Error("Invalid user email.");
-      error.status = 400;
-      throw error;
-    }
-    normalized.email = sanitizedEmail;
-  }
-  return normalized;
 }
 
 /**
@@ -129,7 +146,7 @@ export async function GET(request) {
 
 export async function POST(request) {
   try {
-    const userData = normalizeUserInput(await request.json(), { requireJwt: true });
+    const userData = normalizeUserInput(await request.json(), { requireEmail: true, requireJwt: true });
     const user = await UserService.addUser(userData);
     return new Response(JSON.stringify(getSafeUser(user)), {
       status: 200,
@@ -148,7 +165,7 @@ export async function PUT(request) {
   try {
     const searchParams = request.nextUrl.searchParams;
     const id = searchParams.get("id");
-    const userData = normalizeUserInput(await request.json(), { requireJwt: false });
+    const userData = normalizeUserInput(await request.json(), { requireEmail: false, requireJwt: false });
     const user = await UserService.editUser(id, userData);
     return new Response(JSON.stringify(getSafeUser(user)), {
       status: 200,

--- a/src/lib/DataSanitizer.js
+++ b/src/lib/DataSanitizer.js
@@ -8,12 +8,16 @@ export class DataSanitizer {
     if (typeof email !== "string") {
       return "";
     }
-    // Normalize and remove non-printable/control chars to prevent injection/spoofing.
-    const normalized = email
-      .normalize("NFKC")
-      .replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g, "")
-      .trim()
-      .replace(/\s+/g, "");
+    const trimmed = email.normalize("NFKC").trim();
+    // Reject addresses containing any whitespace to avoid mutating identity-like values.
+    if (/\s/.test(trimmed)) {
+      return "";
+    }
+    // Remove non-printable/control chars to prevent injection/spoofing.
+    const normalized = trimmed.replace(
+      /[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g,
+      "",
+    );
     const atIndex = normalized.indexOf("@");
     const hasSingleAt = atIndex > 0 && atIndex === normalized.lastIndexOf("@") && atIndex < normalized.length - 1;
     if (!hasSingleAt) {

--- a/src/lib/DataSanitizer.js
+++ b/src/lib/DataSanitizer.js
@@ -1,4 +1,6 @@
 export class DataSanitizer {
+  static #LOG_MAX_LENGTH = 512;
+
   /**
    * Method used to sanitize email into a safe, normalized representation
    * @param {String} email Raw email value
@@ -29,6 +31,26 @@ export class DataSanitizer {
       return "";
     }
     return `${localPart}@${domainPart}`;
+  }
+
+  /**
+   * Method used to sanitize dynamic text before interpolation into logs
+   * @param {String} value Raw dynamic value used in logs
+   * @param {Number} maxLength Maximum output length
+   * @returns single-line log-safe text representation
+   */
+  static sanitizeTextForLog(value, maxLength = DataSanitizer.#LOG_MAX_LENGTH) {
+    if (typeof value !== "string") {
+      return "";
+    }
+    const boundedLength = Number.isInteger(maxLength) && maxLength > 0 ? maxLength : DataSanitizer.#LOG_MAX_LENGTH;
+    return value
+      .normalize("NFKC")
+      .replace(/[\r\n\t]+/g, " ")
+      .replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g, "")
+      .replace(/\s{2,}/g, " ")
+      .trim()
+      .slice(0, boundedLength);
   }
 
   /**

--- a/src/lib/DataSanitizer.js
+++ b/src/lib/DataSanitizer.js
@@ -66,7 +66,9 @@ export class DataSanitizer {
     }
     const boundedLength =
       Number.isInteger(maxLength) && maxLength > 0 ? maxLength : DataSanitizer.#FILE_TOKEN_MAX_LENGTH;
-    const sanitized = value
+    // Bound processing cost for extremely large input while preserving enough characters for cleanup.
+    const boundedInput = value.slice(0, boundedLength * 4);
+    const sanitized = boundedInput
       .normalize("NFKC")
       .replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g, "")
       .replace(/[^A-Za-z0-9._-]/g, "_")

--- a/src/lib/DataSanitizer.js
+++ b/src/lib/DataSanitizer.js
@@ -47,7 +47,7 @@ export class DataSanitizer {
     const boundedLength = Number.isInteger(maxLength) && maxLength > 0 ? maxLength : DataSanitizer.#LOG_MAX_LENGTH;
     return value
       .normalize("NFKC")
-      .replace(/[\r\n\t]+/g, " ")
+      .replace(/[\r\n\t\u2028\u2029]+/g, " ")
       .replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g, "")
       .replace(/\s{2,}/g, " ")
       .trim()

--- a/src/lib/DataSanitizer.js
+++ b/src/lib/DataSanitizer.js
@@ -40,7 +40,7 @@ export class DataSanitizer {
    * @param {Number} maxLength Maximum output length
    * @returns single-line log-safe text representation
    */
-  static sanitizeTextForLog(value, maxLength = DataSanitizer.#LOG_MAX_LENGTH) {
+  static sanitizeText(value, maxLength = DataSanitizer.#LOG_MAX_LENGTH) {
     if (typeof value !== "string") {
       return "";
     }

--- a/src/lib/DataSanitizer.js
+++ b/src/lib/DataSanitizer.js
@@ -1,5 +1,6 @@
 export class DataSanitizer {
   static #LOG_MAX_LENGTH = 512;
+  static #FILE_TOKEN_MAX_LENGTH = 120;
 
   /**
    * Method used to sanitize email into a safe, normalized representation
@@ -51,6 +52,28 @@ export class DataSanitizer {
       .replace(/\s{2,}/g, " ")
       .trim()
       .slice(0, boundedLength);
+  }
+
+  /**
+   * Method used to sanitize user-derived values used in file names
+   * @param {String} value Raw token value
+   * @param {Number} maxLength Maximum output length
+   * @returns file-safe token, or fallback token when input cannot be sanitized
+   */
+  static sanitizeFileToken(value, maxLength = DataSanitizer.#FILE_TOKEN_MAX_LENGTH) {
+    if (typeof value !== "string") {
+      return "unknown";
+    }
+    const boundedLength =
+      Number.isInteger(maxLength) && maxLength > 0 ? maxLength : DataSanitizer.#FILE_TOKEN_MAX_LENGTH;
+    const sanitized = value
+      .normalize("NFKC")
+      .replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g, "")
+      .replace(/[^A-Za-z0-9._-]/g, "_")
+      .replace(/_+/g, "_")
+      .replace(/^[._-]+|[._-]+$/g, "")
+      .slice(0, boundedLength);
+    return sanitized || "unknown";
   }
 
   /**

--- a/src/lib/DataWorker.js
+++ b/src/lib/DataWorker.js
@@ -81,6 +81,15 @@ function workerError(message, user = null) {
 }
 
 /**
+ * Method used to retrieve log-safe monitor name
+ * @param {Object} monitor Monitor context object
+ * @returns single-line safe monitor name for logs
+ */
+function getSafeMonitorName(monitor) {
+  return DataSanitizer.sanitizeTextForLog(monitor?.parent == null ? "" : String(monitor.parent));
+}
+
+/**
  * Method used to verify two input values against each other
  * @param {Number} val1 First value to be verified
  * @param {String} operator The operator used to verify both values
@@ -107,7 +116,8 @@ function verify(val1, operator, val2) {
  * @returns path with input user's timestamp file name
  */
 function getUserTimestampFile(user) {
-  return `${SEND_ROOT_DIR}/${user.email}_timestamps.json`;
+  const safeEmailToken = DataSanitizer.sanitizeFileToken(user?.email);
+  return `${SEND_ROOT_DIR}/${safeEmailToken}_timestamps.json`;
 }
 
 /**
@@ -181,8 +191,9 @@ function updateSendTimestamp(user, monitorId) {
  * @returns notifier type when available, null otherwise
  */
 async function getNotifierType(monitor, user) {
+  const safeMonitorName = getSafeMonitorName(monitor);
   if (monitor?.notifier_id == null) {
-    workerWarn(`Monitor ${monitor.parent} has no notifier configured.`, user);
+    workerWarn(`Monitor ${safeMonitorName} has no notifier configured.`, user);
     return null;
   }
   const notifierId = String(monitor.notifier_id);
@@ -212,11 +223,11 @@ async function getNotifierType(monitor, user) {
     return null;
   }
   if (0 === notifierData.length) {
-    workerWarn(`Notifier not configured for monitor ${monitor.parent}.`, user);
+    workerWarn(`Notifier not configured for monitor ${safeMonitorName}.`, user);
     return null;
   }
   if (1 !== notifierData.length) {
-    workerError(`Received multiple notifiers for monitor ${monitor.parent}!`, user);
+    workerError(`Received multiple notifiers for monitor ${safeMonitorName}!`, user);
     return null;
   }
 
@@ -254,10 +265,11 @@ async function checkData(user) {
     // filter out enabled monitors which were not notified in their timeframe (cooldown)
     const enabledMonitors = await MonitorService.filterMonitors({ user: currentUser.id, enabled: true });
     const monitorsToCheck = enabledMonitors.filter((monitor) => {
+      const safeMonitorName = getSafeMonitorName(monitor);
       const sendInterval = monitor.interval || SEND_INTERVAL;
       if (checkSendTimestamp(currentUser, monitor.parent, sendInterval)) {
         workerInfo(
-          `Skipping ${monitor.parent}: Notification was sent in the last ${sendInterval / 1_000} seconds.`,
+          `Skipping ${safeMonitorName}: Notification was sent in the last ${sendInterval / 1_000} seconds.`,
           currentUser,
         );
         return false;
@@ -303,10 +315,11 @@ async function checkData(user) {
       await Promise.allSettled(
         monitorBatch.map(async (monitor) => {
           try {
+            const safeMonitorName = getSafeMonitorName(monitor);
             const monitorItemId = DataUtils.nameToId(monitor.parent);
             const scraperItem = scraperDataByName.get(monitorItemId);
             if (!scraperItem) {
-              workerError(`Cannot find ${monitor.parent} in scraper data...`, currentUser);
+              workerError(`Cannot find ${safeMonitorName} in scraper data...`, currentUser);
               return;
             }
             if (verify(parseFloat(scraperItem.data), monitor.condition, parseFloat(monitor.threshold))) {
@@ -314,7 +327,7 @@ async function checkData(user) {
               if (!notifierType) {
                 return;
               }
-              workerInfo(`Sending notification: ${monitor.parent} over threshold!`, currentUser);
+              workerInfo(`Sending notification: ${safeMonitorName} over threshold!`, currentUser);
               const matchedNotifiers = NotifierCatalog.getSupportedNotifiers()
                 .keys()
                 .filter((notifier) => notifierType === notifier);
@@ -357,7 +370,7 @@ async function checkData(user) {
                 }),
               );
             } else {
-              workerInfo(`Skipping ${monitor.parent}: Threshold value was not met.`, currentUser);
+              workerInfo(`Skipping ${safeMonitorName}: Threshold value was not met.`, currentUser);
             }
           } catch (error) {
             workerError(error.message, currentUser);

--- a/src/lib/DataWorker.js
+++ b/src/lib/DataWorker.js
@@ -49,7 +49,7 @@ function getLogPrefix(level, user) {
  * @param {Object} user User context related to the log line
  */
 function workerLog(level, message, user = null) {
-  const safeMessage = DataSanitizer.sanitizeTextForLog(message == null ? "" : String(message));
+  const safeMessage = DataSanitizer.sanitizeText(message == null ? "" : String(message));
   console[level](`${getLogPrefix(level, user)}${safeMessage}`);
 }
 
@@ -86,7 +86,7 @@ function workerError(message, user = null) {
  * @returns single-line safe monitor name for logs
  */
 function getSafeMonitorName(monitor) {
-  return DataSanitizer.sanitizeTextForLog(monitor?.parent == null ? "" : String(monitor.parent));
+  return DataSanitizer.sanitizeText(monitor?.parent == null ? "" : String(monitor.parent));
 }
 
 /**

--- a/src/lib/DataWorker.js
+++ b/src/lib/DataWorker.js
@@ -116,8 +116,10 @@ function verify(val1, operator, val2) {
  * @returns path with input user's timestamp file name
  */
 function getUserTimestampFile(user) {
+  const safeUserKeyToken = DataSanitizer.sanitizeFileToken(getUserCacheKey(user));
   const safeEmailToken = DataSanitizer.sanitizeFileToken(user?.email);
-  return `${SEND_ROOT_DIR}/${safeEmailToken}_timestamps.json`;
+  const emailSuffix = safeEmailToken !== "unknown" ? `_${safeEmailToken}` : "";
+  return `${SEND_ROOT_DIR}/${safeUserKeyToken}${emailSuffix}_timestamps.json`;
 }
 
 /**
@@ -126,7 +128,13 @@ function getUserTimestampFile(user) {
  * @returns stable cache key for user-related in-memory maps
  */
 function getUserCacheKey(user) {
-  return String(user.id || user.email);
+  if (user?.id != null && user.id !== "") {
+    return String(user.id);
+  }
+  if (typeof user?.email === "string" && user.email !== "") {
+    return user.email;
+  }
+  return "unknown-user";
 }
 
 /**

--- a/src/lib/DataWorker.js
+++ b/src/lib/DataWorker.js
@@ -49,7 +49,8 @@ function getLogPrefix(level, user) {
  * @param {Object} user User context related to the log line
  */
 function workerLog(level, message, user = null) {
-  console[level](`${getLogPrefix(level, user)}${message}`);
+  const safeMessage = DataSanitizer.sanitizeTextForLog(message == null ? "" : String(message));
+  console[level](`${getLogPrefix(level, user)}${safeMessage}`);
 }
 
 /**

--- a/src/lib/RequestUtils.js
+++ b/src/lib/RequestUtils.js
@@ -144,7 +144,7 @@ export class RequestUtils {
 
         await this.#cancelResponseBody(response);
         console.warn(
-          DataSanitizer.sanitizeTextForLog(
+          DataSanitizer.sanitizeText(
             `Request ${method} failed with status ${response.status}. Retrying ${attempt + 1}/${config.retries}...`,
           ),
         );
@@ -154,7 +154,7 @@ export class RequestUtils {
         }
         const message = error.name === "AbortError" ? `Request timeout after ${config.timeout} ms` : error.message;
         console.warn(
-          DataSanitizer.sanitizeTextForLog(
+          DataSanitizer.sanitizeText(
             `Request ${method} failed: ${message}. Retrying ${attempt + 1}/${config.retries}...`,
           ),
         );

--- a/src/lib/RequestUtils.js
+++ b/src/lib/RequestUtils.js
@@ -1,3 +1,5 @@
+import { DataSanitizer } from "./DataSanitizer.js";
+
 export class RequestUtils {
   static #RETRYABLE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
   static #DEFAULT_TIMEOUT = 8_000;
@@ -142,14 +144,20 @@ export class RequestUtils {
 
         await this.#cancelResponseBody(response);
         console.warn(
-          `Request ${method} failed with status ${response.status}. Retrying ${attempt + 1}/${config.retries}...`,
+          DataSanitizer.sanitizeTextForLog(
+            `Request ${method} failed with status ${response.status}. Retrying ${attempt + 1}/${config.retries}...`,
+          ),
         );
       } catch (error) {
         if (!canRetry || attempt === config.retries) {
           throw error;
         }
         const message = error.name === "AbortError" ? `Request timeout after ${config.timeout} ms` : error.message;
-        console.warn(`Request ${method} failed: ${message}. Retrying ${attempt + 1}/${config.retries}...`);
+        console.warn(
+          DataSanitizer.sanitizeTextForLog(
+            `Request ${method} failed: ${message}. Retrying ${attempt + 1}/${config.retries}...`,
+          ),
+        );
       } finally {
         clearTimeout(timeoutId);
       }

--- a/tests/app/api/monitor/route.test.js
+++ b/tests/app/api/monitor/route.test.js
@@ -80,6 +80,18 @@ describe("app/api/monitor route", () => {
     });
   });
 
+  test("GET sanitizes parent and condition query filters", async () => {
+    MonitorService.filterMonitors.mockResolvedValue([]);
+
+    await GET(reqWithUrl("http://test/api/monitor?user=7&parent=btc%0Aspoof&condition=%3E%0A"));
+
+    expect(MonitorService.filterMonitors).toHaveBeenCalledWith({
+      parent: "btc spoof",
+      condition: ">",
+      user: 7,
+    });
+  });
+
   test("POST creates monitor when notifier belongs to user", async () => {
     NotifierService.filterNotifiers.mockResolvedValue([{ id: 9 }]);
     MonitorService.addMonitor.mockResolvedValue({ id: 12 });
@@ -91,6 +103,20 @@ describe("app/api/monitor route", () => {
     expect(body).toEqual({ id: 12 });
     expect(NotifierService.filterNotifiers).toHaveBeenCalledWith({ id: 9, user: 7 });
     expect(MonitorService.addMonitor).toHaveBeenCalledWith({ user: 7, notifier: 9, parent: "btc" });
+  });
+
+  test("POST sanitizes monitor payload text fields", async () => {
+    NotifierService.filterNotifiers.mockResolvedValue([{ id: 9 }]);
+    MonitorService.addMonitor.mockResolvedValue({ id: 13, parent: "btc spoof", condition: ">" });
+
+    await POST(reqWithUrl("http://test/api/monitor", { user: 7, notifier: 9, parent: "btc\nspoof", condition: ">\n" }));
+
+    expect(MonitorService.addMonitor).toHaveBeenCalledWith({
+      user: 7,
+      notifier: 9,
+      parent: "btc spoof",
+      condition: ">",
+    });
   });
 
   test("POST returns 400 for invalid notifier id", async () => {

--- a/tests/app/api/monitor/route.test.js
+++ b/tests/app/api/monitor/route.test.js
@@ -119,6 +119,24 @@ describe("app/api/monitor route", () => {
     });
   });
 
+  test("POST returns 400 when monitor parent sanitizes to empty", async () => {
+    const response = await POST(reqWithUrl("http://test/api/monitor", { user: 7, notifier: 9, parent: "\u202E" }));
+    const body = await response.json();
+
+    expect(MonitorService.addMonitor).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid monitor parent");
+  });
+
+  test("POST returns 400 when monitor condition is unsupported", async () => {
+    const response = await POST(reqWithUrl("http://test/api/monitor", { user: 7, notifier: 9, parent: "btc", condition: "abc" }));
+    const body = await response.json();
+
+    expect(MonitorService.addMonitor).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid monitor condition");
+  });
+
   test("POST returns 400 for invalid notifier id", async () => {
     const response = await POST(reqWithUrl("http://test/api/monitor", { user: 7, notifier: "bad", parent: "btc" }));
     const body = await response.json();
@@ -168,6 +186,15 @@ describe("app/api/monitor route", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({ id: 1, notifier: 9, parent: "btc" });
+  });
+
+  test("PUT returns 400 when monitor condition sanitizes to invalid value", async () => {
+    const response = await PUT(reqWithUrl("http://test/api/monitor?id=1&user=7", { notifier: 9, condition: "\u202E" }));
+    const body = await response.json();
+
+    expect(MonitorService.editMonitorForUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid monitor condition");
   });
 
   test("DELETE returns deleted monitor count", async () => {

--- a/tests/app/api/notifier/route.test.js
+++ b/tests/app/api/notifier/route.test.js
@@ -81,6 +81,18 @@ describe("app/api/notifier route", () => {
     });
   });
 
+  test("GET sanitizes notifier query text filters", async () => {
+    NotifierService.filterNotifiers.mockResolvedValue([]);
+
+    await GET(reqWithUrl("http://test/api/notifier?user=7&type=email%0A&sender=bot%0Aname"));
+
+    expect(NotifierService.filterNotifiers).toHaveBeenCalledWith({
+      type: "email",
+      sender: "bot name",
+      user: 7,
+    });
+  });
+
   test("GET preserves null notifiers from service output", async () => {
     NotifierService.filterNotifiers.mockResolvedValue([null]);
 
@@ -166,6 +178,28 @@ describe("app/api/notifier route", () => {
 
     expect(NotifierService.addNotifier).toHaveBeenCalledWith({ user: 7, type: "email", origin: "", password: "" });
     expect(body).toEqual({ id: 2, type: "email", origin: "", password: "" });
+  });
+
+  test("POST without type sanitizes notifier payload text fields", async () => {
+    NotifierService.addNotifier.mockResolvedValue({ id: 5, type: "email", sender: "bot name", origin: "gmail", password: "sec ret" });
+
+    await POST(
+      reqWithUrl("http://test/api/notifier", {
+        user: 7,
+        type: "email\n",
+        sender: "bot\nname",
+        origin: "gmail\n",
+        password: "sec\nret",
+      }),
+    );
+
+    expect(NotifierService.addNotifier).toHaveBeenCalledWith({
+      user: 7,
+      type: "email",
+      sender: "bot name",
+      origin: "gmail",
+      password: "sec ret",
+    });
   });
 
   test("PUT returns 404 when notifier does not exist", async () => {

--- a/tests/app/api/notifier/route.test.js
+++ b/tests/app/api/notifier/route.test.js
@@ -169,24 +169,40 @@ describe("app/api/notifier route", () => {
   });
 
   test("POST without type creates notifier when required origin is provided", async () => {
-    NotifierService.addNotifier.mockResolvedValue({ id: 2, type: "email", origin: "smtp.gmail.com", password: "" });
+    NotifierService.addNotifier.mockResolvedValue({
+      id: 2,
+      type: "email",
+      sender: "alerts@test.com",
+      origin: "smtp.gmail.com",
+      password: "",
+    });
 
     const response = await POST(
-      reqWithUrl("http://test/api/notifier", { user: 7, type: "email", origin: "smtp.gmail.com", password: "PRIVATE" }),
+      reqWithUrl("http://test/api/notifier", { user: 7, type: "email", sender: "alerts@test.com", origin: "smtp.gmail.com", password: "PRIVATE" }),
     );
     const body = await response.json();
 
     expect(NotifierService.addNotifier).toHaveBeenCalledWith({
       user: 7,
       type: "email",
+      sender: "alerts@test.com",
       origin: "smtp.gmail.com",
       password: "",
     });
-    expect(body).toEqual({ id: 2, type: "email", origin: "PRIVATE", password: "" });
+    expect(body).toEqual({ id: 2, type: "email", origin: "PRIVATE", password: "", sender: "alerts@test.com" });
+  });
+
+  test("POST without type returns 400 when sender is missing", async () => {
+    const response = await POST(reqWithUrl("http://test/api/notifier", { user: 7, type: "email", origin: "smtp.gmail.com" }));
+    const body = await response.json();
+
+    expect(NotifierService.addNotifier).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Notifier sender is required");
   });
 
   test("POST without type returns 400 when origin is missing", async () => {
-    const response = await POST(reqWithUrl("http://test/api/notifier", { user: 7, type: "email", password: "secret" }));
+    const response = await POST(reqWithUrl("http://test/api/notifier", { user: 7, type: "email", sender: "alerts@test.com", password: "secret" }));
     const body = await response.json();
 
     expect(NotifierService.addNotifier).not.toHaveBeenCalled();

--- a/tests/app/api/notifier/route.test.js
+++ b/tests/app/api/notifier/route.test.js
@@ -168,16 +168,30 @@ describe("app/api/notifier route", () => {
     expect(body.message).toContain("Cannot find configured 'email' notifier.");
   });
 
-  test("POST without type creates notifier and normalizes placeholders", async () => {
-    NotifierService.addNotifier.mockResolvedValue({ id: 2, type: "email", origin: "", password: "" });
+  test("POST without type creates notifier when required origin is provided", async () => {
+    NotifierService.addNotifier.mockResolvedValue({ id: 2, type: "email", origin: "smtp.gmail.com", password: "" });
 
     const response = await POST(
-      reqWithUrl("http://test/api/notifier", { user: 7, type: "email", origin: "PRIVATE", password: "PRIVATE" }),
+      reqWithUrl("http://test/api/notifier", { user: 7, type: "email", origin: "smtp.gmail.com", password: "PRIVATE" }),
     );
     const body = await response.json();
 
-    expect(NotifierService.addNotifier).toHaveBeenCalledWith({ user: 7, type: "email", origin: "", password: "" });
-    expect(body).toEqual({ id: 2, type: "email", origin: "", password: "" });
+    expect(NotifierService.addNotifier).toHaveBeenCalledWith({
+      user: 7,
+      type: "email",
+      origin: "smtp.gmail.com",
+      password: "",
+    });
+    expect(body).toEqual({ id: 2, type: "email", origin: "PRIVATE", password: "" });
+  });
+
+  test("POST without type returns 400 when origin is missing", async () => {
+    const response = await POST(reqWithUrl("http://test/api/notifier", { user: 7, type: "email", password: "secret" }));
+    const body = await response.json();
+
+    expect(NotifierService.addNotifier).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Notifier origin is required");
   });
 
   test("POST without type sanitizes non-sensitive fields and preserves credential whitespace", async () => {

--- a/tests/app/api/notifier/route.test.js
+++ b/tests/app/api/notifier/route.test.js
@@ -180,16 +180,22 @@ describe("app/api/notifier route", () => {
     expect(body).toEqual({ id: 2, type: "email", origin: "", password: "" });
   });
 
-  test("POST without type sanitizes notifier payload text fields", async () => {
-    NotifierService.addNotifier.mockResolvedValue({ id: 5, type: "email", sender: "bot name", origin: "gmail", password: "sec ret" });
+  test("POST without type sanitizes non-sensitive fields and preserves credential whitespace", async () => {
+    NotifierService.addNotifier.mockResolvedValue({
+      id: 5,
+      type: "email",
+      sender: "bot name",
+      origin: " smtp.gmail.com ",
+      password: "pa  ss",
+    });
 
     await POST(
       reqWithUrl("http://test/api/notifier", {
         user: 7,
         type: "email\n",
         sender: "bot\nname",
-        origin: "gmail\n",
-        password: "sec\nret",
+        origin: " smtp.gmail.com ",
+        password: "pa  ss",
       }),
     );
 
@@ -197,9 +203,26 @@ describe("app/api/notifier route", () => {
       user: 7,
       type: "email",
       sender: "bot name",
-      origin: "gmail",
-      password: "sec ret",
+      origin: " smtp.gmail.com ",
+      password: "pa  ss",
     });
+  });
+
+  test("POST without type returns 400 for disallowed control chars in credential fields", async () => {
+    const response = await POST(
+      reqWithUrl("http://test/api/notifier", {
+        user: 7,
+        type: "email",
+        sender: "bot",
+        origin: "smtp\n.gmail.com",
+        password: "secret",
+      }),
+    );
+    const body = await response.json();
+
+    expect(NotifierService.addNotifier).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid notifier origin");
   });
 
   test("PUT returns 404 when notifier does not exist", async () => {

--- a/tests/app/api/notifier/route.test.js
+++ b/tests/app/api/notifier/route.test.js
@@ -225,6 +225,23 @@ describe("app/api/notifier route", () => {
     expect(body.message).toContain("Invalid notifier origin");
   });
 
+  test("POST without type returns 400 for unicode line separators in credential fields", async () => {
+    const response = await POST(
+      reqWithUrl("http://test/api/notifier", {
+        user: 7,
+        type: "email",
+        sender: "bot",
+        origin: "smtp\u2028gmail.com",
+        password: "secret",
+      }),
+    );
+    const body = await response.json();
+
+    expect(NotifierService.addNotifier).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid notifier origin");
+  });
+
   test("PUT returns 404 when notifier does not exist", async () => {
     NotifierService.editNotifierForUser.mockResolvedValue(null);
 

--- a/tests/app/api/user/route.test.js
+++ b/tests/app/api/user/route.test.js
@@ -67,9 +67,18 @@ describe("app/api/user route", () => {
   test("GET drops jwt filter when sanitized id/email filters are missing", async () => {
     UserService.filterUsers.mockResolvedValue([]);
 
-    await GET(reqWithUrl("http://test/api/user?email=user%0A%40example.com&jwt=abc%0Adef"));
+    await GET(reqWithUrl("http://test/api/user?email=user%0A%40example.com&jwt=abcdef"));
 
     expect(UserService.filterUsers).toHaveBeenCalledWith({});
+  });
+
+  test("GET returns 400 for jwt query with disallowed control characters", async () => {
+    const response = await GET(reqWithUrl("http://test/api/user?jwt=abc%0Adef"));
+    const body = await response.json();
+
+    expect(UserService.filterUsers).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid user JWT");
   });
 
   test("GET forwards id/email/jwt query filters together", async () => {
@@ -89,13 +98,22 @@ describe("app/api/user route", () => {
     expect(body.message).toContain("User JWT is required");
   });
 
+  test("POST returns 400 when email is missing", async () => {
+    const response = await POST(reqWithUrl("http://test/api/user", { jwt: "token" }));
+    const body = await response.json();
+
+    expect(UserService.addUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("User email is required");
+  });
+
   test("POST returns 400 for invalid sanitized email payload", async () => {
     const response = await POST(reqWithUrl("http://test/api/user", { email: "a b@x.com", jwt: "abc\ndef" }));
     const body = await response.json();
 
     expect(UserService.addUser).not.toHaveBeenCalled();
     expect(response.status).toBe(400);
-    expect(body.message).toContain("Invalid user email");
+    expect(body.message).toContain("Invalid user JWT");
   });
 
   test("POST returns error when payload is null", async () => {

--- a/tests/app/api/user/route.test.js
+++ b/tests/app/api/user/route.test.js
@@ -64,6 +64,14 @@ describe("app/api/user route", () => {
     expect(body).toEqual([{ id: 2, email: "b@b.com", jwt: "PRIVATE" }]);
   });
 
+  test("GET sanitizes email and jwt query filters", async () => {
+    UserService.filterUsers.mockResolvedValue([]);
+
+    await GET(reqWithUrl("http://test/api/user?email=user%0A%40example.com&jwt=abc%0Adef"));
+
+    expect(UserService.filterUsers).toHaveBeenCalledWith({ jwt: "abc def" });
+  });
+
   test("GET forwards id/email/jwt query filters together", async () => {
     UserService.filterUsers.mockResolvedValue([{ id: 2, email: "b@b.com", jwt: "t" }]);
 
@@ -80,6 +88,14 @@ describe("app/api/user route", () => {
 
     expect(UserService.addUser).toHaveBeenCalledWith({ email: "c@c.com", jwt: "" });
     expect(body).toEqual({ id: 3, email: "c@c.com", jwt: "" });
+  });
+
+  test("POST sanitizes email and jwt payload fields", async () => {
+    UserService.addUser.mockResolvedValue({ id: 4, email: "", jwt: "abc def" });
+
+    await POST(reqWithUrl("http://test/api/user", { email: "a b@x.com", jwt: "abc\ndef" }));
+
+    expect(UserService.addUser).toHaveBeenCalledWith({ email: "", jwt: "abc def" });
   });
 
   test("POST returns error when payload is null", async () => {

--- a/tests/app/api/user/route.test.js
+++ b/tests/app/api/user/route.test.js
@@ -90,12 +90,13 @@ describe("app/api/user route", () => {
     expect(body).toEqual({ id: 3, email: "c@c.com", jwt: "" });
   });
 
-  test("POST sanitizes email and jwt payload fields", async () => {
-    UserService.addUser.mockResolvedValue({ id: 4, email: "", jwt: "abc def" });
+  test("POST returns 400 for invalid sanitized email payload", async () => {
+    const response = await POST(reqWithUrl("http://test/api/user", { email: "a b@x.com", jwt: "abc\ndef" }));
+    const body = await response.json();
 
-    await POST(reqWithUrl("http://test/api/user", { email: "a b@x.com", jwt: "abc\ndef" }));
-
-    expect(UserService.addUser).toHaveBeenCalledWith({ email: "", jwt: "abc def" });
+    expect(UserService.addUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid user email");
   });
 
   test("POST returns error when payload is null", async () => {
@@ -118,6 +119,15 @@ describe("app/api/user route", () => {
 
     expect(response.status).toBe(200);
     expect(UserService.editUser).toHaveBeenCalledWith("3", { email: "c@c.com", jwt: "" });
+  });
+
+  test("PUT returns 400 for invalid sanitized email payload", async () => {
+    const response = await PUT(reqWithUrl("http://test/api/user?id=3", { email: "bad email", jwt: "x" }));
+    const body = await response.json();
+
+    expect(UserService.editUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid user email");
   });
 
   test("DELETE removes user by id", async () => {

--- a/tests/app/api/user/route.test.js
+++ b/tests/app/api/user/route.test.js
@@ -64,12 +64,12 @@ describe("app/api/user route", () => {
     expect(body).toEqual([{ id: 2, email: "b@b.com", jwt: "PRIVATE" }]);
   });
 
-  test("GET sanitizes email and jwt query filters", async () => {
+  test("GET drops jwt filter when sanitized id/email filters are missing", async () => {
     UserService.filterUsers.mockResolvedValue([]);
 
     await GET(reqWithUrl("http://test/api/user?email=user%0A%40example.com&jwt=abc%0Adef"));
 
-    expect(UserService.filterUsers).toHaveBeenCalledWith({ jwt: "abc def" });
+    expect(UserService.filterUsers).toHaveBeenCalledWith({});
   });
 
   test("GET forwards id/email/jwt query filters together", async () => {

--- a/tests/app/api/user/route.test.js
+++ b/tests/app/api/user/route.test.js
@@ -80,14 +80,13 @@ describe("app/api/user route", () => {
     expect(UserService.filterUsers).toHaveBeenCalledWith({ id: "2", email: "b@b.com", jwt: "token" });
   });
 
-  test("POST normalizes PRIVATE jwt input", async () => {
-    UserService.addUser.mockResolvedValue({ id: 3, email: "c@c.com", jwt: "" });
-
+  test("POST returns 400 when jwt is missing via PRIVATE placeholder", async () => {
     const response = await POST(reqWithUrl("http://test/api/user", { email: "c@c.com", jwt: "PRIVATE" }));
     const body = await response.json();
 
-    expect(UserService.addUser).toHaveBeenCalledWith({ email: "c@c.com", jwt: "" });
-    expect(body).toEqual({ id: 3, email: "c@c.com", jwt: "" });
+    expect(UserService.addUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("User JWT is required");
   });
 
   test("POST returns 400 for invalid sanitized email payload", async () => {
@@ -119,6 +118,15 @@ describe("app/api/user route", () => {
 
     expect(response.status).toBe(200);
     expect(UserService.editUser).toHaveBeenCalledWith("3", { email: "c@c.com", jwt: "" });
+  });
+
+  test("PUT returns 400 for invalid sanitized JWT payload", async () => {
+    const response = await PUT(reqWithUrl("http://test/api/user?id=3", { email: "c@c.com", jwt: "\u202E" }));
+    const body = await response.json();
+
+    expect(UserService.editUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid user JWT");
   });
 
   test("PUT returns 400 for invalid sanitized email payload", async () => {

--- a/tests/lib/DataSanitizer.test.js
+++ b/tests/lib/DataSanitizer.test.js
@@ -45,3 +45,13 @@ test("DataSanitizer.sanitizeTextForLog returns empty string for non-string input
   expect(DataSanitizer.sanitizeTextForLog(undefined)).toBe("");
   expect(DataSanitizer.sanitizeTextForLog(123)).toBe("");
 });
+
+test("DataSanitizer.sanitizeFileToken normalizes unsafe file token characters", () => {
+  const raw = " ../u\nser\\name@example.com ";
+  expect(DataSanitizer.sanitizeFileToken(raw)).toBe("user_name_example.com");
+});
+
+test("DataSanitizer.sanitizeFileToken returns fallback token when empty", () => {
+  expect(DataSanitizer.sanitizeFileToken("...///***")).toBe("unknown");
+  expect(DataSanitizer.sanitizeFileToken(null)).toBe("unknown");
+});

--- a/tests/lib/DataSanitizer.test.js
+++ b/tests/lib/DataSanitizer.test.js
@@ -31,16 +31,21 @@ test("DataSanitizer.sanitizeEmail returns empty string for malformed emails", ()
   expect(DataSanitizer.sanitizeEmail("user@-example.com")).toBe("");
 });
 
-test("DataSanitizer.sanitizeTextForLog returns single-line safe output", () => {
+test("DataSanitizer.sanitizeText returns single-line safe output", () => {
   const raw = "line1\nline2\t\u202Eend";
   expect(DataSanitizer.sanitizeText(raw)).toBe("line1 line2 end");
 });
 
-test("DataSanitizer.sanitizeTextForLog truncates output to requested length", () => {
+test("DataSanitizer.sanitizeText normalizes unicode line separators", () => {
+  const raw = "line1\u2028line2\u2029line3";
+  expect(DataSanitizer.sanitizeText(raw)).toBe("line1 line2 line3");
+});
+
+test("DataSanitizer.sanitizeText truncates output to requested length", () => {
   expect(DataSanitizer.sanitizeText("abcdef", 4)).toBe("abcd");
 });
 
-test("DataSanitizer.sanitizeTextForLog returns empty string for non-string input", () => {
+test("DataSanitizer.sanitizeText returns empty string for non-string input", () => {
   expect(DataSanitizer.sanitizeText(null)).toBe("");
   expect(DataSanitizer.sanitizeText(undefined)).toBe("");
   expect(DataSanitizer.sanitizeText(123)).toBe("");

--- a/tests/lib/DataSanitizer.test.js
+++ b/tests/lib/DataSanitizer.test.js
@@ -1,8 +1,14 @@
 import { DataSanitizer } from "../../src/lib/DataSanitizer.js";
 
-test("DataSanitizer.sanitizeEmail normalizes spaces and lowercases domain", () => {
+test("DataSanitizer.sanitizeEmail trims surrounding spaces and lowercases domain", () => {
   const sanitized = DataSanitizer.sanitizeEmail("  User.Name+tag@Example.COM  ");
   expect(sanitized).toBe("User.Name+tag@example.com");
+});
+
+test("DataSanitizer.sanitizeEmail rejects emails containing whitespace", () => {
+  expect(DataSanitizer.sanitizeEmail("a b@x.com")).toBe("");
+  expect(DataSanitizer.sanitizeEmail("user@exa mple.com")).toBe("");
+  expect(DataSanitizer.sanitizeEmail("user\t@example.com")).toBe("");
 });
 
 test("DataSanitizer.sanitizeEmail removes zero-width and bidi control characters", () => {

--- a/tests/lib/DataSanitizer.test.js
+++ b/tests/lib/DataSanitizer.test.js
@@ -60,3 +60,9 @@ test("DataSanitizer.sanitizeFileToken returns fallback token when empty", () => 
   expect(DataSanitizer.sanitizeFileToken("...///***")).toBe("unknown");
   expect(DataSanitizer.sanitizeFileToken(null)).toBe("unknown");
 });
+
+test("DataSanitizer.sanitizeFileToken keeps output bounded for large input", () => {
+  const raw = "a".repeat(10_000);
+  const sanitized = DataSanitizer.sanitizeFileToken(raw, 64);
+  expect(sanitized).toHaveLength(64);
+});

--- a/tests/lib/DataSanitizer.test.js
+++ b/tests/lib/DataSanitizer.test.js
@@ -30,3 +30,18 @@ test("DataSanitizer.sanitizeEmail returns empty string for malformed emails", ()
   expect(DataSanitizer.sanitizeEmail(".user@example.com")).toBe("");
   expect(DataSanitizer.sanitizeEmail("user@-example.com")).toBe("");
 });
+
+test("DataSanitizer.sanitizeTextForLog returns single-line safe output", () => {
+  const raw = "line1\nline2\t\u202Eend";
+  expect(DataSanitizer.sanitizeTextForLog(raw)).toBe("line1 line2 end");
+});
+
+test("DataSanitizer.sanitizeTextForLog truncates output to requested length", () => {
+  expect(DataSanitizer.sanitizeTextForLog("abcdef", 4)).toBe("abcd");
+});
+
+test("DataSanitizer.sanitizeTextForLog returns empty string for non-string input", () => {
+  expect(DataSanitizer.sanitizeTextForLog(null)).toBe("");
+  expect(DataSanitizer.sanitizeTextForLog(undefined)).toBe("");
+  expect(DataSanitizer.sanitizeTextForLog(123)).toBe("");
+});

--- a/tests/lib/DataSanitizer.test.js
+++ b/tests/lib/DataSanitizer.test.js
@@ -33,17 +33,17 @@ test("DataSanitizer.sanitizeEmail returns empty string for malformed emails", ()
 
 test("DataSanitizer.sanitizeTextForLog returns single-line safe output", () => {
   const raw = "line1\nline2\t\u202Eend";
-  expect(DataSanitizer.sanitizeTextForLog(raw)).toBe("line1 line2 end");
+  expect(DataSanitizer.sanitizeText(raw)).toBe("line1 line2 end");
 });
 
 test("DataSanitizer.sanitizeTextForLog truncates output to requested length", () => {
-  expect(DataSanitizer.sanitizeTextForLog("abcdef", 4)).toBe("abcd");
+  expect(DataSanitizer.sanitizeText("abcdef", 4)).toBe("abcd");
 });
 
 test("DataSanitizer.sanitizeTextForLog returns empty string for non-string input", () => {
-  expect(DataSanitizer.sanitizeTextForLog(null)).toBe("");
-  expect(DataSanitizer.sanitizeTextForLog(undefined)).toBe("");
-  expect(DataSanitizer.sanitizeTextForLog(123)).toBe("");
+  expect(DataSanitizer.sanitizeText(null)).toBe("");
+  expect(DataSanitizer.sanitizeText(undefined)).toBe("");
+  expect(DataSanitizer.sanitizeText(123)).toBe("");
 });
 
 test("DataSanitizer.sanitizeFileToken normalizes unsafe file token characters", () => {

--- a/tests/lib/RequestUtils.test.js
+++ b/tests/lib/RequestUtils.test.js
@@ -152,6 +152,20 @@ describe("RequestUtils", () => {
     expect(response.status).toBe(200);
   });
 
+  test("sanitizes retry warning log message content", async () => {
+    global.fetch
+      .mockRejectedValueOnce(new Error("temporary\nnetwork\tissue"))
+      .mockResolvedValueOnce(makeResponse({ status: 200, text: "ok" }));
+
+    await RequestUtils.fetchWithRetry("/api/test", {}, { timeout: 50, retries: 1, retryDelay: 0 });
+
+    expect(warnSpy).toHaveBeenCalled();
+    const firstWarnArg = String(warnSpy.mock.calls[0][0]);
+    expect(firstWarnArg).toContain("temporary network issue");
+    expect(firstWarnArg).not.toContain("\n");
+    expect(firstWarnArg).not.toContain("\t");
+  });
+
   test("returns final retryable response when retry budget is exhausted", async () => {
     global.fetch
       .mockResolvedValueOnce(makeResponse({ status: 503, text: "retry-1" }))


### PR DESCRIPTION
This patch fixes #95 
* Introduced dedicated sanitizers for email, log text, and file tokens.
* Hardened DataWorker logging and user-derived timestamp filenames.
* Added API-boundary text sanitization for monitor/user/notifier routes.
* Sanitized dynamic retry warning logs in RequestUtils.