### PR TITLE
Added scrollable content hint component

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 const eslintConfig = [
   ...nextCoreWebVitals,
   {
-    ignores: [".next/**", "out/**", "build/**"],
+    ignores: [".next/**", "out/**", "build/**", "coverage/**"],
     rules: {
       "react-hooks/set-state-in-effect": "off",
     },

--- a/src/app/api/docs/page.js
+++ b/src/app/api/docs/page.js
@@ -1,4 +1,5 @@
 import SwaggerDocs from "@/components/SwaggerDocs";
+import ScrollHintContainer from "@/components/ScrollHintContainer";
 
 export const metadata = {
   title: "API docs | data-monitor",
@@ -7,8 +8,8 @@ export const metadata = {
 
 export default function ApiDocsPage() {
   return (
-    <section className="api-docs-page">
+    <ScrollHintContainer className="api-docs-page" hintText="More content below, scroll down" hideScrollbar>
       <SwaggerDocs />
-    </section>
+    </ScrollHintContainer>
   );
 }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -91,23 +91,30 @@ div.page-content {
   min-height: 0;
 }
 
-section.api-docs-page {
+section.scroll-hint-container {
   position: relative;
   width: 100%;
   height: 100%;
   align-self: stretch;
   overflow: auto;
   background: #ffffff;
+}
+
+section.scroll-hint-container--hide-scrollbar {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
 
-section.api-docs-page::-webkit-scrollbar {
+section.scroll-hint-container--hide-scrollbar::-webkit-scrollbar {
   width: 0;
   height: 0;
 }
 
-div.api-docs-scroll-hint {
+section.api-docs-page {
+  background: #ffffff;
+}
+
+div.scroll-hint-badge {
   position: sticky;
   left: 50%;
   bottom: 0.75rem;

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -91,7 +91,7 @@ div.page-content {
   min-height: 0;
 }
 
-section.scroll-hint-container {
+.scroll-hint-container {
   position: relative;
   width: 100%;
   height: 100%;
@@ -100,12 +100,12 @@ section.scroll-hint-container {
   background: #ffffff;
 }
 
-section.scroll-hint-container--hide-scrollbar {
+.scroll-hint-container--hide-scrollbar {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
 
-section.scroll-hint-container--hide-scrollbar::-webkit-scrollbar {
+.scroll-hint-container--hide-scrollbar::-webkit-scrollbar {
   width: 0;
   height: 0;
 }
@@ -114,7 +114,7 @@ section.api-docs-page {
   background: #ffffff;
 }
 
-div.scroll-hint-badge {
+.scroll-hint-badge {
   position: sticky;
   left: 50%;
   bottom: 0.75rem;

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -110,6 +110,13 @@ div.page-content {
   height: 0;
 }
 
+div.scroll-hint-content {
+  display: flow-root;
+  margin-top: 10px;
+  width: 100%;
+  min-width: 0;
+}
+
 section.api-docs-page {
   background: #ffffff;
 }
@@ -359,8 +366,11 @@ section#notifiers-section {
 
 section#notifiers-section div.notifier-cards-div {
   @apply flex-1 overflow-y-auto;
-  @apply flex flex-col items-start gap-5;
   @apply my-5 sm:my-2 mx-5 sm:mx-0;
+}
+
+section#notifiers-section div.notifier-cards-div > div.scroll-hint-content {
+  @apply flex flex-col items-start gap-5;
 }
 
 section#notifiers-section div.notifier-card {

--- a/src/components/ScrollHintContainer.jsx
+++ b/src/components/ScrollHintContainer.jsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 
 export default function ScrollHintContainer({
   children,
+  as = "section",
   className = "",
   hintText = "More content below, scroll down",
   hideScrollbar = true,
@@ -47,10 +48,12 @@ export default function ScrollHintContainer({
     .filter(Boolean)
     .join(" ");
 
+  const Root = as;
+
   return (
-    <section ref={containerRef} className={classes}>
+    <Root ref={containerRef} className={classes}>
       {children}
       {showHint ? <div className="scroll-hint-badge">{hintText}</div> : null}
-    </section>
+    </Root>
   );
 }

--- a/src/components/ScrollHintContainer.jsx
+++ b/src/components/ScrollHintContainer.jsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export default function ScrollHintContainer({
+  children,
+  className = "",
+  hintText = "More content below, scroll down",
+  hideScrollbar = true,
+  threshold = 8,
+}) {
+  const containerRef = useRef(null);
+  const [showHint, setShowHint] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (container == null) {
+      return;
+    }
+
+    const updateHintVisibility = () => {
+      const remaining = container.scrollHeight - container.clientHeight - container.scrollTop;
+      setShowHint(container.scrollHeight > container.clientHeight && remaining > threshold);
+    };
+
+    updateHintVisibility();
+    container.addEventListener("scroll", updateHintVisibility, { passive: true });
+    window.addEventListener("resize", updateHintVisibility);
+
+    const observer =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(updateHintVisibility)
+        : null;
+    observer?.observe(container);
+
+    const delayedCheck = window.setTimeout(updateHintVisibility, 250);
+
+    return () => {
+      container.removeEventListener("scroll", updateHintVisibility);
+      window.removeEventListener("resize", updateHintVisibility);
+      observer?.disconnect();
+      window.clearTimeout(delayedCheck);
+    };
+  }, [threshold]);
+
+  const classes = ["scroll-hint-container", hideScrollbar ? "scroll-hint-container--hide-scrollbar" : "", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <section ref={containerRef} className={classes}>
+      {children}
+      {showHint ? <div className="scroll-hint-badge">{hintText}</div> : null}
+    </section>
+  );
+}

--- a/src/components/ScrollHintContainer.jsx
+++ b/src/components/ScrollHintContainer.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export default function ScrollHintContainer({
   children,
@@ -11,39 +11,58 @@ export default function ScrollHintContainer({
   threshold = 8,
   ...rest
 }) {
-  const containerRef = useRef(null);
+  const [containerNode, setContainerNode] = useState(null);
+  const [contentNode, setContentNode] = useState(null);
   const [showHint, setShowHint] = useState(false);
 
+  const handleContainerRef = useCallback((node) => {
+    setContainerNode(node);
+  }, []);
+
+  const handleContentRef = useCallback((node) => {
+    setContentNode(node);
+  }, []);
+
   useEffect(() => {
-    const container = containerRef.current;
-    if (container == null) {
+    if (containerNode == null) {
       return;
     }
 
     const updateHintVisibility = () => {
-      const remaining = container.scrollHeight - container.clientHeight - container.scrollTop;
-      setShowHint(container.scrollHeight > container.clientHeight && remaining > threshold);
+      const remaining = containerNode.scrollHeight - containerNode.clientHeight - containerNode.scrollTop;
+      setShowHint(containerNode.scrollHeight > containerNode.clientHeight && remaining > threshold);
     };
 
     updateHintVisibility();
-    container.addEventListener("scroll", updateHintVisibility, { passive: true });
+    containerNode.addEventListener("scroll", updateHintVisibility, { passive: true });
     window.addEventListener("resize", updateHintVisibility);
 
-    const observer =
+    const resizeObserver =
       typeof ResizeObserver !== "undefined"
         ? new ResizeObserver(updateHintVisibility)
         : null;
-    observer?.observe(container);
+    if (contentNode != null) {
+      resizeObserver?.observe(contentNode);
+    }
+
+    const mutationObserver =
+      typeof MutationObserver !== "undefined"
+        ? new MutationObserver(updateHintVisibility)
+        : null;
+    if (contentNode != null) {
+      mutationObserver?.observe(contentNode, { childList: true, subtree: true, characterData: true });
+    }
 
     const delayedCheck = window.setTimeout(updateHintVisibility, 250);
 
     return () => {
-      container.removeEventListener("scroll", updateHintVisibility);
+      containerNode.removeEventListener("scroll", updateHintVisibility);
       window.removeEventListener("resize", updateHintVisibility);
-      observer?.disconnect();
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
       window.clearTimeout(delayedCheck);
     };
-  }, [threshold]);
+  }, [containerNode, contentNode, threshold]);
 
   const classes = ["scroll-hint-container", hideScrollbar ? "scroll-hint-container--hide-scrollbar" : "", className]
     .filter(Boolean)
@@ -52,8 +71,10 @@ export default function ScrollHintContainer({
   const Root = as;
 
   return (
-    <Root ref={containerRef} className={classes} {...rest}>
-      {children}
+    <Root ref={handleContainerRef} className={classes} {...rest}>
+      <div ref={handleContentRef} className="scroll-hint-content">
+        {children}
+      </div>
       {showHint ? <div className="scroll-hint-badge">{hintText}</div> : null}
     </Root>
   );

--- a/src/components/ScrollHintContainer.jsx
+++ b/src/components/ScrollHintContainer.jsx
@@ -9,6 +9,7 @@ export default function ScrollHintContainer({
   hintText = "More content below, scroll down",
   hideScrollbar = true,
   threshold = 8,
+  ...rest
 }) {
   const containerRef = useRef(null);
   const [showHint, setShowHint] = useState(false);
@@ -51,7 +52,7 @@ export default function ScrollHintContainer({
   const Root = as;
 
   return (
-    <Root ref={containerRef} className={classes}>
+    <Root ref={containerRef} className={classes} {...rest}>
       {children}
       {showHint ? <div className="scroll-hint-badge">{hintText}</div> : null}
     </Root>

--- a/src/components/SwaggerDocs.jsx
+++ b/src/components/SwaggerDocs.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import SwaggerUIBundle from "swagger-ui-dist/swagger-ui-es-bundle";
 import SwaggerUIStandalonePreset from "swagger-ui-dist/swagger-ui-standalone-preset";
 
@@ -23,7 +23,6 @@ function initializeSwaggerUi() {
 }
 
 export default function SwaggerDocs() {
-  const [showScrollHint, setShowScrollHint] = useState(false);
   const swaggerUiRef = useRef(null);
 
   useEffect(() => {
@@ -37,33 +36,5 @@ export default function SwaggerDocs() {
     };
   }, []);
 
-  useEffect(() => {
-    const container = document.querySelector("section.api-docs-page");
-    if (container == null) {
-      return;
-    }
-
-    const updateHintVisibility = () => {
-      const remaining = container.scrollHeight - container.clientHeight - container.scrollTop;
-      setShowScrollHint(container.scrollHeight > container.clientHeight && remaining > 8);
-    };
-
-    updateHintVisibility();
-    container.addEventListener("scroll", updateHintVisibility, { passive: true });
-    window.addEventListener("resize", updateHintVisibility);
-    const delayedCheck = window.setTimeout(updateHintVisibility, 250);
-
-    return () => {
-      container.removeEventListener("scroll", updateHintVisibility);
-      window.removeEventListener("resize", updateHintVisibility);
-      window.clearTimeout(delayedCheck);
-    };
-  }, []);
-
-  return (
-    <>
-      <div id="swagger-ui" />
-      {showScrollHint ? <div className="api-docs-scroll-hint">More content below, scroll down</div> : null}
-    </>
-  );
+  return <div id="swagger-ui" />;
 }

--- a/src/views/MonitorsPage.jsx
+++ b/src/views/MonitorsPage.jsx
@@ -5,7 +5,7 @@ import Spinner from "@/widgets/Spinner";
 
 const MonitorsPage = ({ loading, data }) => {
   return (
-    <ScrollHintContainer id="data-section" hintText="More monitors below, scroll down" hideScrollbar={false}>
+    <ScrollHintContainer id="data-section" hintText="More monitors below, scroll down" hideScrollbar={true}>
       {loading ? <Spinner /> : data.length > 0 ? <DataCards data={data} /> : <EmptyCards whatToAdd={"monitor"} />}
     </ScrollHintContainer>
   );

--- a/src/views/MonitorsPage.jsx
+++ b/src/views/MonitorsPage.jsx
@@ -1,12 +1,13 @@
 import DataCards from "@/components/DataCards";
 import EmptyCards from "@/components/EmptyCards";
+import ScrollHintContainer from "@/components/ScrollHintContainer";
 import Spinner from "@/widgets/Spinner";
 
 const MonitorsPage = ({ loading, data }) => {
   return (
-    <section id="data-section">
+    <ScrollHintContainer id="data-section" hintText="More monitors below, scroll down" hideScrollbar={false}>
       {loading ? <Spinner /> : data.length > 0 ? <DataCards data={data} /> : <EmptyCards whatToAdd={"monitor"} />}
-    </section>
+    </ScrollHintContainer>
   );
 };
 

--- a/src/views/NotifiersPage.jsx
+++ b/src/views/NotifiersPage.jsx
@@ -4,6 +4,7 @@ import { LoginContext } from "@/context/Contexts";
 import { RequestUtils } from "@/lib/RequestUtils";
 import NotifierCard from "@/components/NotifierCard";
 import EmptyCards from "@/components/EmptyCards";
+import ScrollHintContainer from "@/components/ScrollHintContainer";
 import { NotifierCatalog } from "@/notifiers/core/NotifierCatalog";
 
 const NotifiersPage = () => {
@@ -101,7 +102,14 @@ const NotifiersPage = () => {
 
   return (
     <section id="notifiers-section">
-      <div className="notifier-cards-div">{getCards()}</div>
+      <ScrollHintContainer
+        as="div"
+        className="notifier-cards-div"
+        hintText="More notifiers below, scroll down"
+        hideScrollbar={false}
+      >
+        {getCards()}
+      </ScrollHintContainer>
       <button className="add-notifier" onClick={addNotifier} disabled={addDisabled}>
         add
       </button>

--- a/src/views/NotifiersPage.jsx
+++ b/src/views/NotifiersPage.jsx
@@ -106,7 +106,7 @@ const NotifiersPage = () => {
         as="div"
         className="notifier-cards-div"
         hintText="More notifiers below, scroll down"
-        hideScrollbar={false}
+        hideScrollbar={true}
       >
         {getCards()}
       </ScrollHintContainer>

--- a/tests/components/ScrollHintContainer.test.jsx
+++ b/tests/components/ScrollHintContainer.test.jsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ScrollHintContainer from "../../src/components/ScrollHintContainer.jsx";
+
+describe("ScrollHintContainer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders hint when content overflows and hides hint near bottom", async () => {
+    render(
+      <ScrollHintContainer className="api-docs-page" hintText="More content below, scroll down" hideScrollbar>
+        <div style={{ height: "400px" }}>Content</div>
+      </ScrollHintContainer>
+    );
+
+    const container = document.querySelector("section.scroll-hint-container");
+    let scrollTop = 0;
+
+    Object.defineProperty(container, "clientHeight", {
+      configurable: true,
+      get: () => 100,
+    });
+    Object.defineProperty(container, "scrollHeight", {
+      configurable: true,
+      get: () => 320,
+    });
+    Object.defineProperty(container, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value) => {
+        scrollTop = value;
+      },
+    });
+
+    fireEvent(window, new Event("resize"));
+
+    expect(await screen.findByText("More content below, scroll down")).toBeInTheDocument();
+
+    scrollTop = 260;
+    fireEvent.scroll(container);
+
+    await waitFor(() => {
+      expect(screen.queryByText("More content below, scroll down")).not.toBeInTheDocument();
+    });
+  });
+
+  test("applies hide-scrollbar modifier only when requested", () => {
+    const { rerender } = render(
+      <ScrollHintContainer hideScrollbar className="custom-wrap">
+        <div>Child</div>
+      </ScrollHintContainer>
+    );
+
+    let container = document.querySelector("section.scroll-hint-container");
+    expect(container.className).toContain("scroll-hint-container--hide-scrollbar");
+    expect(container.className).toContain("custom-wrap");
+
+    rerender(
+      <ScrollHintContainer hideScrollbar={false} className="custom-wrap">
+        <div>Child</div>
+      </ScrollHintContainer>
+    );
+
+    container = document.querySelector("section.scroll-hint-container");
+    expect(container.className).not.toContain("scroll-hint-container--hide-scrollbar");
+  });
+});

--- a/tests/components/ScrollHintContainer.test.jsx
+++ b/tests/components/ScrollHintContainer.test.jsx
@@ -76,4 +76,67 @@ describe("ScrollHintContainer", () => {
     const root = document.querySelector("div.scroll-hint-container.custom-wrap");
     expect(root).toBeInTheDocument();
   });
+
+  test("rebinds behavior when root element changes", async () => {
+    const { rerender } = render(
+      <ScrollHintContainer as="section" hintText="More content below, scroll down" hideScrollbar>
+        <div style={{ height: "400px" }}>Content</div>
+      </ScrollHintContainer>
+    );
+
+    const firstContainer = document.querySelector("section.scroll-hint-container");
+    let firstScrollTop = 0;
+
+    Object.defineProperty(firstContainer, "clientHeight", {
+      configurable: true,
+      get: () => 100,
+    });
+    Object.defineProperty(firstContainer, "scrollHeight", {
+      configurable: true,
+      get: () => 320,
+    });
+    Object.defineProperty(firstContainer, "scrollTop", {
+      configurable: true,
+      get: () => firstScrollTop,
+      set: (value) => {
+        firstScrollTop = value;
+      },
+    });
+
+    fireEvent(window, new Event("resize"));
+    expect(await screen.findByText("More content below, scroll down")).toBeInTheDocument();
+
+    rerender(
+      <ScrollHintContainer as="div" hintText="More content below, scroll down" hideScrollbar>
+        <div style={{ height: "400px" }}>Content</div>
+      </ScrollHintContainer>
+    );
+
+    const nextContainer = document.querySelector("div.scroll-hint-container");
+    expect(document.querySelector("section.scroll-hint-container")).not.toBeInTheDocument();
+    let nextScrollTop = 0;
+
+    Object.defineProperty(nextContainer, "clientHeight", {
+      configurable: true,
+      get: () => 100,
+    });
+    Object.defineProperty(nextContainer, "scrollHeight", {
+      configurable: true,
+      get: () => 320,
+    });
+    Object.defineProperty(nextContainer, "scrollTop", {
+      configurable: true,
+      get: () => nextScrollTop,
+      set: (value) => {
+        nextScrollTop = value;
+      },
+    });
+
+    nextScrollTop = 280;
+    fireEvent.scroll(nextContainer);
+
+    await waitFor(() => {
+      expect(screen.queryByText("More content below, scroll down")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/tests/components/ScrollHintContainer.test.jsx
+++ b/tests/components/ScrollHintContainer.test.jsx
@@ -14,7 +14,7 @@ describe("ScrollHintContainer", () => {
       </ScrollHintContainer>
     );
 
-    const container = document.querySelector("section.scroll-hint-container");
+    const container = document.querySelector(".scroll-hint-container");
     let scrollTop = 0;
 
     Object.defineProperty(container, "clientHeight", {
@@ -52,7 +52,7 @@ describe("ScrollHintContainer", () => {
       </ScrollHintContainer>
     );
 
-    let container = document.querySelector("section.scroll-hint-container");
+    let container = document.querySelector(".scroll-hint-container");
     expect(container.className).toContain("scroll-hint-container--hide-scrollbar");
     expect(container.className).toContain("custom-wrap");
 
@@ -62,7 +62,18 @@ describe("ScrollHintContainer", () => {
       </ScrollHintContainer>
     );
 
-    container = document.querySelector("section.scroll-hint-container");
+    container = document.querySelector(".scroll-hint-container");
     expect(container.className).not.toContain("scroll-hint-container--hide-scrollbar");
+  });
+
+  test("renders custom root element when `as` is provided", () => {
+    render(
+      <ScrollHintContainer as="div" className="custom-wrap">
+        <div>Child</div>
+      </ScrollHintContainer>
+    );
+
+    const root = document.querySelector("div.scroll-hint-container.custom-wrap");
+    expect(root).toBeInTheDocument();
   });
 });

--- a/tests/components/SwaggerDocs.test.jsx
+++ b/tests/components/SwaggerDocs.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 
 jest.mock("swagger-ui-dist/swagger-ui-es-bundle", () => ({
   __esModule: true,
@@ -42,41 +42,4 @@ describe("SwaggerDocs", () => {
     expect(swaggerUiInstance.destroy).toHaveBeenCalled();
   });
 
-  test("shows and hides floating scroll hint based on remaining scroll", async () => {
-    render(
-      <section className="api-docs-page">
-        <SwaggerDocs />
-      </section>
-    );
-
-    const container = document.querySelector("section.api-docs-page");
-    let scrollTop = 0;
-
-    Object.defineProperty(container, "clientHeight", {
-      configurable: true,
-      get: () => 100,
-    });
-    Object.defineProperty(container, "scrollHeight", {
-      configurable: true,
-      get: () => 320,
-    });
-    Object.defineProperty(container, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value) => {
-        scrollTop = value;
-      },
-    });
-
-    fireEvent(window, new Event("resize"));
-
-    expect(await screen.findByText("More content below, scroll down")).toBeInTheDocument();
-
-    scrollTop = 260;
-    fireEvent.scroll(container);
-
-    await waitFor(() => {
-      expect(screen.queryByText("More content below, scroll down")).not.toBeInTheDocument();
-    });
-  });
 });

--- a/tests/views/MonitorsPage.test.jsx
+++ b/tests/views/MonitorsPage.test.jsx
@@ -19,7 +19,10 @@ jest.mock("@/widgets/Spinner", () => ({
 
 describe("MonitorsPage", () => {
   test("shows spinner when loading", () => {
-    render(<MonitorsPage loading={true} data={[]} />);
+    const { container } = render(<MonitorsPage loading={true} data={[]} />);
+
+    const root = container.querySelector("section#data-section.scroll-hint-container");
+    expect(root).toBeInTheDocument();
 
     expect(screen.getByTestId("spinner")).toBeInTheDocument();
   });

--- a/tests/views/NotifiersPage.test.jsx
+++ b/tests/views/NotifiersPage.test.jsx
@@ -73,7 +73,10 @@ describe("NotifiersPage", () => {
       json: async () => [],
     });
 
-    renderWithLogin({ userIdValue: 3, token: "token-3" });
+    const { container } = renderWithLogin({ userIdValue: 3, token: "token-3" });
+
+    const cardsWrapper = container.querySelector("div.notifier-cards-div.scroll-hint-container");
+    expect(cardsWrapper).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByTestId("empty-cards")).toHaveTextContent("empty:notifier");


### PR DESCRIPTION
This patch fixes #104 
Now a separate ScrollHintContainer is added which can (and is !) used in the whole application, not only in the docs.