### PR TITLE
Fix DB notifier remove issue related to foreign key problem

### DIFF
--- a/src/components/DataMonitor.jsx
+++ b/src/components/DataMonitor.jsx
@@ -99,9 +99,17 @@ const DataMonitor = ({ parentName }) => {
           toast.error("Error: Received multiple monitor entries...");
           return;
         }
+        // initialize monitor state independently from notifier lookup
+        setId(monitorData[0].id ?? MONITOR_DEFAULTS.id);
+        setEnabled(monitorData[0].enabled ?? MONITOR_DEFAULTS.enabled);
+        setCondition(monitorData[0].condition ?? MONITOR_DEFAULTS.condition);
+        setThreshold(monitorData[0].threshold ?? MONITOR_DEFAULTS.threshold);
+        setInterval(monitorData[0].interval ?? MONITOR_DEFAULTS.interval);
         // get notifier name from ID
         const currNotifierId = monitorData[0].notifier_id;
         if (currNotifierId == null) {
+          setNotifierId(-1);
+          setNotifierType(MONITOR_DEFAULTS.notifier);
           return;
         }
         setNotifierId(currNotifierId);
@@ -115,18 +123,15 @@ const DataMonitor = ({ parentName }) => {
           return;
         }
         if (0 === notifierData.length) {
+          setNotifierId(-1);
+          setNotifierType(MONITOR_DEFAULTS.notifier);
           return;
         }
         if (1 !== notifierData.length) {
           toast.error("Error: Received multiple notifier entries...");
           return;
         }
-        // initialize UI with monitor and notifier data
-        setId(monitorData[0].id ?? MONITOR_DEFAULTS.id);
-        setEnabled(monitorData[0].enabled ?? MONITOR_DEFAULTS.enabled);
-        setCondition(monitorData[0].condition ?? MONITOR_DEFAULTS.condition);
-        setThreshold(monitorData[0].threshold ?? MONITOR_DEFAULTS.threshold);
-        setInterval(monitorData[0].interval ?? MONITOR_DEFAULTS.interval);
+        // notifier entry still exists, so bind monitor to resolved notifier option
         if (notifierData[0].type) {
           setNotifierType(`${notifierData[0].type}${OPTION_VALUE_DELIMITER}${currNotifierId}`);
         }

--- a/src/lib/DatabaseQuery.js
+++ b/src/lib/DatabaseQuery.js
@@ -1,5 +1,6 @@
 import { AppConfig } from "../config/AppConfig.js";
 import { Pool } from "pg";
+import { AsyncLocalStorage } from "node:async_hooks";
 import dotenv from "dotenv";
 
 if (process.env.NODE_ENV !== "production") {
@@ -14,21 +15,32 @@ const pool = new Pool({
   password: databaseConfig.password,
 });
 
-export const DatabaseQuery = (text, params) => pool.query(text, params);
+const transactionContext = new AsyncLocalStorage();
+
+export const DatabaseQuery = (text, params) => {
+  const context = transactionContext.getStore();
+  if (context?.client != null) {
+    return context.client.query(text, params);
+  }
+  return pool.query(text, params);
+};
 
 /**
- * Method used to execute callback in a database transaction scope
+ * Method used to execute operation in a database transaction scope
  * @param {Function} operation async operation executed between BEGIN and COMMIT
  * @returns operation result when transaction commits successfully
  */
 export const DatabaseTransaction = async (operation) => {
-  await DatabaseQuery("BEGIN");
+  const client = await pool.connect();
   try {
-    const result = await operation();
-    await DatabaseQuery("COMMIT");
+    await client.query("BEGIN");
+    const result = await transactionContext.run({ client }, async () => operation());
+    await client.query("COMMIT");
     return result;
   } catch (error) {
-    await DatabaseQuery("ROLLBACK");
+    await client.query("ROLLBACK");
     throw error;
+  } finally {
+    client.release();
   }
 };

--- a/src/lib/DatabaseQuery.js
+++ b/src/lib/DatabaseQuery.js
@@ -15,3 +15,20 @@ const pool = new Pool({
 });
 
 export const DatabaseQuery = (text, params) => pool.query(text, params);
+
+/**
+ * Method used to execute callback in a database transaction scope
+ * @param {Function} operation async operation executed between BEGIN and COMMIT
+ * @returns operation result when transaction commits successfully
+ */
+export const DatabaseTransaction = async (operation) => {
+  await DatabaseQuery("BEGIN");
+  try {
+    const result = await operation();
+    await DatabaseQuery("COMMIT");
+    return result;
+  } catch (error) {
+    await DatabaseQuery("ROLLBACK");
+    throw error;
+  }
+};

--- a/src/model/MonitorService.js
+++ b/src/model/MonitorService.js
@@ -117,4 +117,18 @@ export class MonitorService {
     ]);
     return rowCount;
   }
+
+  /**
+   * Method used to detach monitors from a notifier for a specific user scope
+   * @param {Number} notifierId notifier identifier to detach from monitors
+   * @param {Number} userId owner identifier used for authorization scope
+   * @returns number of updated monitor object(s)
+   */
+  static async clearNotifierForUser(notifierId, userId) {
+    const { rowCount } = await DatabaseQuery(
+      `UPDATE ${MonitorService.#DB_TABLE_NAME} SET notifier_id = NULL WHERE notifier_id = $1 AND user_id = $2`,
+      [notifierId, userId],
+    );
+    return rowCount;
+  }
 }

--- a/src/model/NotifierService.js
+++ b/src/model/NotifierService.js
@@ -1,7 +1,7 @@
 import { DatabaseQuery } from "../lib/DatabaseQuery.js";
 import { DataCrypto } from "../lib/DataCrypto.js";
 import { Notifier } from "./Notifier.js";
-import { Monitor } from "./Monitor.js";
+import { MonitorService } from "./MonitorService.js";
 
 export class NotifierService {
   static #DB_TABLE_NAME = Notifier.getTableName();
@@ -125,10 +125,9 @@ export class NotifierService {
    * @returns number of deleted notifier object(s)
    */
   static async deleteNotifierForUser(id, userId) {
-    const monitorTableName = Monitor.getTableName();
     await DatabaseQuery("BEGIN");
     try {
-      await DatabaseQuery(`UPDATE ${monitorTableName} SET notifier_id = NULL WHERE notifier_id = $1 AND user_id = $2`, [id, userId]);
+      await MonitorService.clearNotifierForUser(id, userId);
       const { rowCount } = await DatabaseQuery(`DELETE FROM ${NotifierService.#DB_TABLE_NAME} WHERE id = $1 AND user_id = $2`, [
         id,
         userId,

--- a/src/model/NotifierService.js
+++ b/src/model/NotifierService.js
@@ -1,4 +1,4 @@
-import { DatabaseQuery } from "../lib/DatabaseQuery.js";
+import { DatabaseQuery, DatabaseTransaction } from "../lib/DatabaseQuery.js";
 import { DataCrypto } from "../lib/DataCrypto.js";
 import { Notifier } from "./Notifier.js";
 import { MonitorService } from "./MonitorService.js";
@@ -125,19 +125,14 @@ export class NotifierService {
    * @returns number of deleted notifier object(s)
    */
   static async deleteNotifierForUser(id, userId) {
-    await DatabaseQuery("BEGIN");
-    try {
+    return DatabaseTransaction(async () => {
       await MonitorService.clearNotifierForUser(id, userId);
       const { rowCount } = await DatabaseQuery(`DELETE FROM ${NotifierService.#DB_TABLE_NAME} WHERE id = $1 AND user_id = $2`, [
         id,
         userId,
       ]);
-      await DatabaseQuery("COMMIT");
       return rowCount;
-    } catch (error) {
-      await DatabaseQuery("ROLLBACK");
-      throw error;
-    }
+    });
   }
 
   /**

--- a/src/model/NotifierService.js
+++ b/src/model/NotifierService.js
@@ -1,6 +1,7 @@
 import { DatabaseQuery } from "../lib/DatabaseQuery.js";
 import { DataCrypto } from "../lib/DataCrypto.js";
 import { Notifier } from "./Notifier.js";
+import { Monitor } from "./Monitor.js";
 
 export class NotifierService {
   static #DB_TABLE_NAME = Notifier.getTableName();
@@ -124,11 +125,20 @@ export class NotifierService {
    * @returns number of deleted notifier object(s)
    */
   static async deleteNotifierForUser(id, userId) {
-    const { rowCount } = await DatabaseQuery(`DELETE FROM ${NotifierService.#DB_TABLE_NAME} WHERE id = $1 AND user_id = $2`, [
-      id,
-      userId,
-    ]);
-    return rowCount;
+    const monitorTableName = Monitor.getTableName();
+    await DatabaseQuery("BEGIN");
+    try {
+      await DatabaseQuery(`UPDATE ${monitorTableName} SET notifier_id = NULL WHERE notifier_id = $1 AND user_id = $2`, [id, userId]);
+      const { rowCount } = await DatabaseQuery(`DELETE FROM ${NotifierService.#DB_TABLE_NAME} WHERE id = $1 AND user_id = $2`, [
+        id,
+        userId,
+      ]);
+      await DatabaseQuery("COMMIT");
+      return rowCount;
+    } catch (error) {
+      await DatabaseQuery("ROLLBACK");
+      throw error;
+    }
   }
 
   /**

--- a/tests/components/DataMonitor.test.jsx
+++ b/tests/components/DataMonitor.test.jsx
@@ -203,6 +203,25 @@ describe("DataMonitor", () => {
     });
   });
 
+  test("keeps monitor settings when monitor has no notifier configured", async () => {
+    global.fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: 21, enabled: true, condition: ">", threshold: "10", interval: 600000, notifier_id: null }],
+      });
+
+    renderWithLogin({ isDemo: false, userId: () => 7, email: "u@test.com", token: "jwt" });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(screen.getByRole("button", { name: "enabled:true" })).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("threshold")).toHaveValue("10");
+      expect(screen.getByLabelText("select")).toHaveValue(">");
+      expect(screen.getByLabelText("notifier")).toHaveValue("config@-1");
+    });
+  });
+
   test("shows multiple notifier entries error", async () => {
     global.fetch
       .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, type: "email" }] })

--- a/tests/lib/DatabaseQuery.test.js
+++ b/tests/lib/DatabaseQuery.test.js
@@ -47,4 +47,73 @@ describe("DatabaseQuery", () => {
     expect(queryMock).toHaveBeenCalledWith("SELECT 1", ["x"]);
     expect(result).toEqual({ rows: [{ id: 1 }] });
   });
+
+  test("DatabaseTransaction commits and returns operation result", async () => {
+    const queryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const poolMock = jest.fn().mockImplementation(() => ({ query: queryMock }));
+
+    jest.doMock("pg", () => ({ Pool: poolMock }));
+    jest.doMock("dotenv", () => ({ __esModule: true, default: { config: jest.fn() } }));
+    jest.doMock("../../src/config/AppConfig.js", () => ({
+      AppConfig: {
+        getConfig: () => ({
+          database: {
+            host: "db-host",
+            port: 5433,
+            name: "db-name",
+            user: "db-user",
+            password: "db-pass",
+          },
+        }),
+      },
+    }));
+
+    process.env.NODE_ENV = "test";
+
+    const { DatabaseQuery, DatabaseTransaction } = await import("../../src/lib/DatabaseQuery.js");
+    const result = await DatabaseTransaction(async () => {
+      await DatabaseQuery("UPDATE x SET y = $1", [1]);
+      return 123;
+    });
+
+    expect(result).toBe(123);
+    expect(queryMock).toHaveBeenNthCalledWith(1, "BEGIN", undefined);
+    expect(queryMock).toHaveBeenNthCalledWith(2, "UPDATE x SET y = $1", [1]);
+    expect(queryMock).toHaveBeenNthCalledWith(3, "COMMIT", undefined);
+  });
+
+  test("DatabaseTransaction rolls back when operation fails", async () => {
+    const queryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const poolMock = jest.fn().mockImplementation(() => ({ query: queryMock }));
+
+    jest.doMock("pg", () => ({ Pool: poolMock }));
+    jest.doMock("dotenv", () => ({ __esModule: true, default: { config: jest.fn() } }));
+    jest.doMock("../../src/config/AppConfig.js", () => ({
+      AppConfig: {
+        getConfig: () => ({
+          database: {
+            host: "db-host",
+            port: 5433,
+            name: "db-name",
+            user: "db-user",
+            password: "db-pass",
+          },
+        }),
+      },
+    }));
+
+    process.env.NODE_ENV = "test";
+
+    const { DatabaseQuery, DatabaseTransaction } = await import("../../src/lib/DatabaseQuery.js");
+    await expect(
+      DatabaseTransaction(async () => {
+        await DatabaseQuery("UPDATE x SET y = $1", [2]);
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(queryMock).toHaveBeenNthCalledWith(1, "BEGIN", undefined);
+    expect(queryMock).toHaveBeenNthCalledWith(2, "UPDATE x SET y = $1", [2]);
+    expect(queryMock).toHaveBeenNthCalledWith(3, "ROLLBACK", undefined);
+  });
 });

--- a/tests/lib/DatabaseQuery.test.js
+++ b/tests/lib/DatabaseQuery.test.js
@@ -50,7 +50,9 @@ describe("DatabaseQuery", () => {
 
   test("DatabaseTransaction commits and returns operation result", async () => {
     const queryMock = jest.fn().mockResolvedValue({ rows: [] });
-    const poolMock = jest.fn().mockImplementation(() => ({ query: queryMock }));
+    const releaseMock = jest.fn();
+    const connectMock = jest.fn().mockResolvedValue({ query: queryMock, release: releaseMock });
+    const poolMock = jest.fn().mockImplementation(() => ({ query: jest.fn(), connect: connectMock }));
 
     jest.doMock("pg", () => ({ Pool: poolMock }));
     jest.doMock("dotenv", () => ({ __esModule: true, default: { config: jest.fn() } }));
@@ -77,14 +79,18 @@ describe("DatabaseQuery", () => {
     });
 
     expect(result).toBe(123);
-    expect(queryMock).toHaveBeenNthCalledWith(1, "BEGIN", undefined);
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(queryMock).toHaveBeenNthCalledWith(1, "BEGIN");
     expect(queryMock).toHaveBeenNthCalledWith(2, "UPDATE x SET y = $1", [1]);
-    expect(queryMock).toHaveBeenNthCalledWith(3, "COMMIT", undefined);
+    expect(queryMock).toHaveBeenNthCalledWith(3, "COMMIT");
+    expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 
   test("DatabaseTransaction rolls back when operation fails", async () => {
     const queryMock = jest.fn().mockResolvedValue({ rows: [] });
-    const poolMock = jest.fn().mockImplementation(() => ({ query: queryMock }));
+    const releaseMock = jest.fn();
+    const connectMock = jest.fn().mockResolvedValue({ query: queryMock, release: releaseMock });
+    const poolMock = jest.fn().mockImplementation(() => ({ query: jest.fn(), connect: connectMock }));
 
     jest.doMock("pg", () => ({ Pool: poolMock }));
     jest.doMock("dotenv", () => ({ __esModule: true, default: { config: jest.fn() } }));
@@ -112,8 +118,10 @@ describe("DatabaseQuery", () => {
       }),
     ).rejects.toThrow("boom");
 
-    expect(queryMock).toHaveBeenNthCalledWith(1, "BEGIN", undefined);
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(queryMock).toHaveBeenNthCalledWith(1, "BEGIN");
     expect(queryMock).toHaveBeenNthCalledWith(2, "UPDATE x SET y = $1", [2]);
-    expect(queryMock).toHaveBeenNthCalledWith(3, "ROLLBACK", undefined);
+    expect(queryMock).toHaveBeenNthCalledWith(3, "ROLLBACK");
+    expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/model/MonitorService.test.js
+++ b/tests/model/MonitorService.test.js
@@ -80,6 +80,11 @@ test("MonitorService methods build expected SQL interactions", async () => {
       const deletedCount = await MonitorService.deleteMonitorForUser(9, 7);
       expect(deletedCount).toBe(1);
       expect(calls[4].params).toEqual([9, 7]);
+
+      const detachedCount = await MonitorService.clearNotifierForUser(2, 7);
+      expect(detachedCount).toBe(1);
+      expect(calls[5].text).toMatch(/UPDATE monitors SET notifier_id = NULL/);
+      expect(calls[5].params).toEqual([2, 7]);
     },
   );
 });

--- a/tests/model/NotifierService.test.js
+++ b/tests/model/NotifierService.test.js
@@ -9,16 +9,24 @@ if (!process.env.CRYPTO_SECRET) {
 
 async function withMockedQuery(handler, callback) {
   const originalQuery = Pool.prototype.query;
+  const originalConnect = Pool.prototype.connect;
   const calls = [];
   Pool.prototype.query = async function query(text, params) {
     calls.push({ text, params });
     return handler(text, params, calls.length - 1);
+  };
+  Pool.prototype.connect = async function connect() {
+    return {
+      query: (text, params) => this.query(text, params),
+      release: jest.fn(),
+    };
   };
 
   try {
     await callback(calls);
   } finally {
     Pool.prototype.query = originalQuery;
+    Pool.prototype.connect = originalConnect;
   }
 }
 

--- a/tests/model/NotifierService.test.js
+++ b/tests/model/NotifierService.test.js
@@ -97,6 +97,12 @@ describe("NotifierService", () => {
           };
         }
         if (callIndex === 4) {
+          return { rows: [] };
+        }
+        if (callIndex === 5) {
+          return { rowCount: 1, rows: [] };
+        }
+        if (callIndex === 6) {
           return { rowCount: 1, rows: [] };
         }
         return { rows: [] };
@@ -137,7 +143,11 @@ describe("NotifierService", () => {
 
         const deleted = await NotifierService.deleteNotifierForUser(2, 3);
         expect(deleted).toBe(1);
-        expect(calls[4].params).toEqual([2, 3]);
+        expect(calls[4].text).toBe("BEGIN");
+        expect(calls[5].text).toMatch(/UPDATE monitors SET notifier_id = NULL/);
+        expect(calls[5].params).toEqual([2, 3]);
+        expect(calls[6].params).toEqual([2, 3]);
+        expect(calls[7].text).toBe("COMMIT");
       },
     );
   });


### PR DESCRIPTION
This patch fixes #102 
Now user is able to remove the notifier, no matter if used or not in the monitor entities.