### PR TITLE
Fixed demo session start issue with authorization errors

### DIFF
--- a/src/components/MenuBar.jsx
+++ b/src/components/MenuBar.jsx
@@ -9,8 +9,13 @@ import { LoginContext, PageContext } from "@/context/Contexts";
 const MenuBar = () => {
   const config = AppConfig.getConfig();
   const router = useRouter();
-  const { isDemo, challenge, logout } = useContext(LoginContext);
+  const { isDemo, challenge, logout, userId } = useContext(LoginContext);
   const { pageId } = useContext(PageContext);
+
+  const getValidUserId = () => {
+    const parsed = Number.parseInt(String(userId()), 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  };
 
   const viewConfig = async (event) => {
     event.preventDefault();
@@ -27,21 +32,37 @@ const MenuBar = () => {
     router.replace("/monitors");
   };
 
+  const cleanupDemoSession = async () => {
+    const logoutResponse = await fetch("/api/scraper/logout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ "demo-user": "user", "demo-pass": "pass" }),
+    });
+    if (!logoutResponse.ok) {
+      return { ok: false, cause: "Issues on backend side" };
+    }
+    const currentUserId = getValidUserId();
+    if (currentUserId == null) {
+      return { ok: false, cause: "Invalid user ID" };
+    }
+    const cleanupResponse = await fetch(`/api/user?id=${currentUserId}`, {
+      method: "DELETE",
+    });
+    if (!cleanupResponse.ok) {
+      return { ok: false, cause: "Cannot remove demo user" };
+    }
+    return { ok: true };
+  };
+
   const userLogout = async (event) => {
     event.preventDefault();
-    const response = !isDemo
-      ? { ok: true }
-      : await fetch("/api/scraper/logout", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ "demo-user": "user", "demo-pass": "pass" }),
-        });
+    let response = isDemo ? await cleanupDemoSession() : { ok: true };
     logout();
     router.replace("/");
     if (response.ok) {
       toast.success("Logout successful!");
     } else {
-      toast.warn("Logout successful, with problems on backend side...");
+      toast.warn(`Logout successful. Warning: ${response.cause}`);
     }
   };
 

--- a/src/components/MenuBar.jsx
+++ b/src/components/MenuBar.jsx
@@ -36,7 +36,7 @@ const MenuBar = () => {
     const logoutResponse = await fetch("/api/scraper/logout", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ "demo-user": "user", "demo-pass": "pass" }),
+      body: JSON.stringify({ "demo-user": "u", "demo-pass": "p" }),
     });
     if (!logoutResponse.ok) {
       return { ok: false, cause: "Issues on backend side" };

--- a/src/context/LoginProvider.jsx
+++ b/src/context/LoginProvider.jsx
@@ -4,14 +4,12 @@ import { useEffect, useState } from "react";
 import { LoginContext } from "@/context/Contexts";
 
 const LoginProvider = ({ children }) => {
-  const DEMO_USER_ID = 7357;
-
   const [id, setId] = useState(-1);
   const [challenge, setChallenge] = useState(null);
   const [token, setToken] = useState(null);
   const [email, setEmail] = useState(null);
+  const [isDemo, setIsDemo] = useState(false);
   const [authReady, setAuthReady] = useState(false);
-  const isDemo = DEMO_USER_ID === id;
   const userLogged = authReady && !!token;
 
   useEffect(() => {
@@ -19,26 +17,32 @@ const LoginProvider = ({ children }) => {
     if (storedToken) {
       setToken(storedToken);
     }
+    const storedDemo = localStorage.getItem("isDemo");
+    setIsDemo(storedDemo === "true");
     setAuthReady(true);
   }, []);
 
-  const login = (id, email, data) => {
+  const login = (id, email, data, demoSession = false) => {
     setId(id);
     setEmail(email);
     setChallenge(data.challenge);
     setToken(data.token);
+    setIsDemo(demoSession);
     localStorage.setItem("id", id);
     localStorage.setItem("token", data.token);
+    localStorage.setItem("isDemo", demoSession ? "true" : "false");
   };
 
-  const demo = (data) => login(DEMO_USER_ID, null, data);
+  const demo = (id, email, data) => login(id, email, data, true);
 
   const logout = () => {
     localStorage.removeItem("token");
     localStorage.removeItem("id");
+    localStorage.removeItem("isDemo");
     setToken(null);
     setChallenge(null);
     setEmail(null);
+    setIsDemo(false);
     setId(-1);
   };
 

--- a/src/lib/AuthTokenUtils.js
+++ b/src/lib/AuthTokenUtils.js
@@ -10,7 +10,12 @@ export function getEmailFromJwt(token) {
       return null;
     }
     const payloadBase64 = payloadRaw.replace(/-/g, "+").replace(/_/g, "/");
-    const json = atob(payloadBase64);
+    const remainder = payloadBase64.length % 4;
+    if (remainder === 1) {
+      return null;
+    }
+    const paddedPayload = remainder === 0 ? payloadBase64 : payloadBase64 + "=".repeat(4 - remainder);
+    const json = atob(paddedPayload);
     const payload = JSON.parse(json);
     const jwtEmail = typeof payload?.email === "string" ? payload.email.trim() : "";
     return jwtEmail || null;

--- a/src/lib/AuthTokenUtils.js
+++ b/src/lib/AuthTokenUtils.js
@@ -1,0 +1,20 @@
+/**
+ * Method used to extract email claim value from JWT payload
+ * @param {String} token JWT string
+ * @returns email from JWT payload when present, otherwise null
+ */
+export function getEmailFromJwt(token) {
+  try {
+    const payloadRaw = String(token).split(".")[1];
+    if (!payloadRaw) {
+      return null;
+    }
+    const payloadBase64 = payloadRaw.replace(/-/g, "+").replace(/_/g, "/");
+    const json = atob(payloadBase64);
+    const payload = JSON.parse(json);
+    const jwtEmail = typeof payload?.email === "string" ? payload.email.trim() : "";
+    return jwtEmail || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/views/HomePage.jsx
+++ b/src/views/HomePage.jsx
@@ -84,8 +84,13 @@ export default function HomePage({ demoEnabled, initError }) {
   const demoLogin = async (event) => {
     event.preventDefault();
     const demoLoginAction = async (loginData) => {
-      const demoEmail = getEmailFromJwt(loginData?.token) || "base@demo.com";
-      const saveResult = await userSave({ email: demoEmail, jwt: loginData.token });
+      const demoToken = loginData?.token;
+      if (!demoToken) {
+        toast.error("Demo login response is missing token.");
+        return false;
+      }
+      const demoEmail = getEmailFromJwt(demoToken) || "base@demo.com";
+      const saveResult = await userSave({ email: demoEmail, jwt: demoToken });
       if (saveResult.id == null) {
         toast.error(saveResult.message);
         return false;

--- a/src/views/HomePage.jsx
+++ b/src/views/HomePage.jsx
@@ -36,28 +36,16 @@ export default function HomePage({ demoEnabled, initError }) {
   }, [initError]);
 
   const userSave = async (userData) => {
-    const getExactUserUrl = RequestUtils.buildUrl("/api/user", { email: userData.email, jwt: userData.jwt });
-    const getExactUserResponse = await fetch(getExactUserUrl);
-    if (!getExactUserResponse.ok) {
-      return { id: undefined, message: await RequestUtils.getResponseMessage(getExactUserResponse) };
+    const getEmailUserUrl = RequestUtils.buildUrl("/api/user", { email: userData.email });
+    const getEmailUserResponse = await fetch(getEmailUserUrl);
+    if (!getEmailUserResponse.ok) {
+      return { id: undefined, message: await RequestUtils.getResponseMessage(getEmailUserResponse) };
     }
-    const exactUsers = await getExactUserResponse.json();
-    if (exactUsers.length > 1) {
+    const emailUsers = await getEmailUserResponse.json();
+    if (emailUsers.length > 1) {
       return { id: undefined, message: "Error: Received multiple user entries." };
     }
-    let existingUser = exactUsers[0];
-    if (!existingUser) {
-      const getEmailUserUrl = RequestUtils.buildUrl("/api/user", { email: userData.email });
-      const getEmailUserResponse = await fetch(getEmailUserUrl);
-      if (!getEmailUserResponse.ok) {
-        return { id: undefined, message: await RequestUtils.getResponseMessage(getEmailUserResponse) };
-      }
-      const emailUsers = await getEmailUserResponse.json();
-      if (emailUsers.length > 1) {
-        return { id: undefined, message: "Error: Received multiple user entries." };
-      }
-      existingUser = emailUsers[0];
-    }
+    const existingUser = emailUsers[0];
     const exists = existingUser != null;
     const idFilter = exists ? `?id=${existingUser.id}` : ``;
     const addUserResponse = await fetch(`/api/user${idFilter}`, {

--- a/src/views/HomePage.jsx
+++ b/src/views/HomePage.jsx
@@ -7,10 +7,27 @@ import { LoginContext } from "@/context/Contexts";
 import { RequestUtils } from "@/lib/RequestUtils";
 
 export default function HomePage({ demoEnabled, initError }) {
+  const DEMO_FALLBACK_EMAIL = "demo.user@data-monitor.local";
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const { demo, login, logout } = useContext(LoginContext);
   const router = useRouter();
+
+  const getEmailFromJwt = (token) => {
+    try {
+      const payloadRaw = String(token).split(".")[1];
+      if (!payloadRaw) {
+        return null;
+      }
+      const payloadBase64 = payloadRaw.replace(/-/g, "+").replace(/_/g, "/");
+      const json = atob(payloadBase64);
+      const payload = JSON.parse(json);
+      const jwtEmail = typeof payload?.email === "string" ? payload.email.trim() : "";
+      return jwtEmail || null;
+    } catch {
+      return null;
+    }
+  };
 
   useEffect(() => {
     if (initError) {
@@ -81,7 +98,13 @@ export default function HomePage({ demoEnabled, initError }) {
   const demoLogin = async (event) => {
     event.preventDefault();
     const demoLoginAction = async (loginData) => {
-      demo(loginData);
+      const demoEmail = getEmailFromJwt(loginData?.token) || DEMO_FALLBACK_EMAIL;
+      const saveResult = await userSave({ email: demoEmail, jwt: loginData.token });
+      if (saveResult.id == null) {
+        toast.error(saveResult.message);
+        return false;
+      }
+      demo(saveResult.id, demoEmail, loginData);
       return true;
     };
     await doLogin(demoLoginAction, { "demo-user": "u", "demo-pass": "p" });

--- a/src/views/HomePage.jsx
+++ b/src/views/HomePage.jsx
@@ -4,30 +4,14 @@ import { useContext, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "react-toastify";
 import { LoginContext } from "@/context/Contexts";
+import { getEmailFromJwt } from "@/lib/AuthTokenUtils";
 import { RequestUtils } from "@/lib/RequestUtils";
 
 export default function HomePage({ demoEnabled, initError }) {
-  const DEMO_FALLBACK_EMAIL = "demo.user@data-monitor.local";
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const { demo, login, logout } = useContext(LoginContext);
   const router = useRouter();
-
-  const getEmailFromJwt = (token) => {
-    try {
-      const payloadRaw = String(token).split(".")[1];
-      if (!payloadRaw) {
-        return null;
-      }
-      const payloadBase64 = payloadRaw.replace(/-/g, "+").replace(/_/g, "/");
-      const json = atob(payloadBase64);
-      const payload = JSON.parse(json);
-      const jwtEmail = typeof payload?.email === "string" ? payload.email.trim() : "";
-      return jwtEmail || null;
-    } catch {
-      return null;
-    }
-  };
 
   useEffect(() => {
     if (initError) {
@@ -100,7 +84,7 @@ export default function HomePage({ demoEnabled, initError }) {
   const demoLogin = async (event) => {
     event.preventDefault();
     const demoLoginAction = async (loginData) => {
-      const demoEmail = getEmailFromJwt(loginData?.token) || DEMO_FALLBACK_EMAIL;
+      const demoEmail = getEmailFromJwt(loginData?.token) || "base@demo.com";
       const saveResult = await userSave({ email: demoEmail, jwt: loginData.token });
       if (saveResult.id == null) {
         toast.error(saveResult.message);

--- a/src/views/HomePage.jsx
+++ b/src/views/HomePage.jsx
@@ -36,16 +36,30 @@ export default function HomePage({ demoEnabled, initError }) {
   }, [initError]);
 
   const userSave = async (userData) => {
-    const getUserResponse = await fetch(`/api/user?email=${userData.email}`);
-    if (!getUserResponse.ok) {
-      return { id: undefined, message: await RequestUtils.getResponseMessage(getUserResponse) };
+    const getExactUserUrl = RequestUtils.buildUrl("/api/user", { email: userData.email, jwt: userData.jwt });
+    const getExactUserResponse = await fetch(getExactUserUrl);
+    if (!getExactUserResponse.ok) {
+      return { id: undefined, message: await RequestUtils.getResponseMessage(getExactUserResponse) };
     }
-    const getUserData = await getUserResponse.json();
-    if (getUserData.length > 1) {
+    const exactUsers = await getExactUserResponse.json();
+    if (exactUsers.length > 1) {
       return { id: undefined, message: "Error: Received multiple user entries." };
     }
-    const exists = getUserData.length === 1;
-    const idFilter = exists ? `?id=${getUserData[0].id}` : ``;
+    let existingUser = exactUsers[0];
+    if (!existingUser) {
+      const getEmailUserUrl = RequestUtils.buildUrl("/api/user", { email: userData.email });
+      const getEmailUserResponse = await fetch(getEmailUserUrl);
+      if (!getEmailUserResponse.ok) {
+        return { id: undefined, message: await RequestUtils.getResponseMessage(getEmailUserResponse) };
+      }
+      const emailUsers = await getEmailUserResponse.json();
+      if (emailUsers.length > 1) {
+        return { id: undefined, message: "Error: Received multiple user entries." };
+      }
+      existingUser = emailUsers[0];
+    }
+    const exists = existingUser != null;
+    const idFilter = exists ? `?id=${existingUser.id}` : ``;
     const addUserResponse = await fetch(`/api/user${idFilter}`, {
       method: exists ? "PUT" : "POST",
       headers: { "Content-Type": "application/json" },

--- a/tests/components/DataMonitor.test.jsx
+++ b/tests/components/DataMonitor.test.jsx
@@ -148,7 +148,9 @@ describe("DataMonitor", () => {
   });
 
   test("shows demo warning when saving in demo mode", async () => {
-    global.fetch.mockResolvedValue({ ok: true, json: async () => [] });
+    global.fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
 
     renderWithLogin({ isDemo: true, userId: () => 7, email: "u@test.com", token: "jwt" });
 
@@ -158,7 +160,10 @@ describe("DataMonitor", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "save" }));
 
-    expect(toastWarnMock).toHaveBeenCalledWith("Notifications are disabled for demo session.");
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(toastWarnMock).toHaveBeenCalledWith("Notifications are disabled for demo session.");
+    });
   });
 
   test("shows missing token error in initializer", async () => {

--- a/tests/components/MenuBar.test.jsx
+++ b/tests/components/MenuBar.test.jsx
@@ -142,7 +142,7 @@ describe("MenuBar", () => {
       expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(logoutMock).toHaveBeenCalled();
       expect(replaceMock).toHaveBeenCalledWith("/");
-      expect(toastWarnMock).toHaveBeenCalledWith("Logout successful, with problems on backend side...");
+      expect(toastWarnMock).toHaveBeenCalledWith("Logout successful. Warning: Cannot remove demo user");
     });
   });
 });

--- a/tests/components/MenuBar.test.jsx
+++ b/tests/components/MenuBar.test.jsx
@@ -58,7 +58,7 @@ describe("MenuBar", () => {
 
   test("shows notifiers button on monitors page", () => {
     renderWithContexts({
-      login: { isDemo: false, challenge: "abc", logout: jest.fn() },
+      login: { isDemo: false, challenge: "abc", logout: jest.fn(), userId: () => 11 },
       page: { pageId: "monitors" },
     });
 
@@ -67,7 +67,7 @@ describe("MenuBar", () => {
 
   test("shows monitors button on notifiers page", () => {
     renderWithContexts({
-      login: { isDemo: false, challenge: "abc", logout: jest.fn() },
+      login: { isDemo: false, challenge: "abc", logout: jest.fn(), userId: () => 11 },
       page: { pageId: "notifiers" },
     });
 
@@ -76,7 +76,7 @@ describe("MenuBar", () => {
 
   test("navigates to scraper config with challenge", () => {
     renderWithContexts({
-      login: { isDemo: false, challenge: "abc", logout: jest.fn() },
+      login: { isDemo: false, challenge: "abc", logout: jest.fn(), userId: () => 11 },
       page: { pageId: "monitors" },
     });
 
@@ -89,7 +89,7 @@ describe("MenuBar", () => {
     const logoutMock = jest.fn();
 
     renderWithContexts({
-      login: { isDemo: false, challenge: "abc", logout: logoutMock },
+      login: { isDemo: false, challenge: "abc", logout: logoutMock, userId: () => 11 },
       page: { pageId: "monitors" },
     });
 
@@ -103,19 +103,43 @@ describe("MenuBar", () => {
     });
   });
 
-  test("demo logout calls backend and warns on backend issue", async () => {
-    global.fetch.mockResolvedValueOnce({ ok: false });
+  test("demo logout calls scraper logout and user cleanup", async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({ ok: true });
     const logoutMock = jest.fn();
 
     renderWithContexts({
-      login: { isDemo: true, challenge: "abc", logout: logoutMock },
+      login: { isDemo: true, challenge: "abc", logout: logoutMock, userId: () => 7357 },
       page: { pageId: "monitors" },
     });
 
     fireEvent.click(screen.getByRole("button", { name: "logout" }));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        "/api/user?id=7357",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+      expect(logoutMock).toHaveBeenCalled();
+      expect(replaceMock).toHaveBeenCalledWith("/");
+      expect(toastSuccessMock).toHaveBeenCalledWith("Logout successful!");
+    });
+  });
+
+  test("demo logout warns on cleanup issue", async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({ ok: false });
+    const logoutMock = jest.fn();
+
+    renderWithContexts({
+      login: { isDemo: true, challenge: "abc", logout: logoutMock, userId: () => 7357 },
+      page: { pageId: "monitors" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "logout" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(logoutMock).toHaveBeenCalled();
       expect(replaceMock).toHaveBeenCalledWith("/");
       expect(toastWarnMock).toHaveBeenCalledWith("Logout successful, with problems on backend side...");

--- a/tests/context/LoginProvider.test.jsx
+++ b/tests/context/LoginProvider.test.jsx
@@ -29,7 +29,7 @@ function LoginConsumer() {
       </button>
       <button
         onClick={() =>
-          ctx.demo({
+          ctx.demo(21, "demo.user@data-monitor.local", {
             token: "demo-token",
             challenge: "demo-challenge",
           })
@@ -94,9 +94,9 @@ describe("LoginProvider", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("is-demo")).toHaveTextContent("true");
-      expect(screen.getByTestId("user-id")).toHaveTextContent("7357");
+      expect(screen.getByTestId("user-id")).toHaveTextContent("21");
       expect(screen.getByTestId("token")).toHaveTextContent("demo-token");
-      expect(screen.getByTestId("email")).toHaveTextContent("");
+      expect(screen.getByTestId("email")).toHaveTextContent("demo.user@data-monitor.local");
     });
   });
 

--- a/tests/lib/AuthTokenUtils.test.js
+++ b/tests/lib/AuthTokenUtils.test.js
@@ -1,0 +1,23 @@
+import { getEmailFromJwt } from "../../src/lib/AuthTokenUtils.js";
+
+describe("AuthTokenUtils.getEmailFromJwt", () => {
+  test("returns email for valid unpadded base64url payload", () => {
+    const token = "header.eyJlbWFpbCI6ImRlbW9AZXhhbXBsZS5jb20ifQ.signature";
+    expect(getEmailFromJwt(token)).toBe("demo@example.com");
+  });
+
+  test("returns email for valid padded base64 payload", () => {
+    const token = "header.eyJlbWFpbCI6ImRlbW9AZXhhbXBsZS5jb20ifQ==.signature";
+    expect(getEmailFromJwt(token)).toBe("demo@example.com");
+  });
+
+  test("returns null for invalid base64 length", () => {
+    const token = "header.a.signature";
+    expect(getEmailFromJwt(token)).toBeNull();
+  });
+
+  test("returns null for missing email claim", () => {
+    const token = "header.eyJzdWIiOiIxMjMifQ.signature";
+    expect(getEmailFromJwt(token)).toBeNull();
+  });
+});

--- a/tests/views/HomePage.test.jsx
+++ b/tests/views/HomePage.test.jsx
@@ -69,10 +69,6 @@ describe("HomePage", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => [],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         json: async () => ({ id: 7 }),
       });
 
@@ -91,7 +87,6 @@ describe("HomePage", () => {
       expect.stringContaining("/api/user?"),
     );
     expect(global.fetch.mock.calls[1][0]).toContain("email=user%40example.com");
-    expect(global.fetch.mock.calls[1][0]).toContain("jwt=jwt-token");
   });
 
   test("handles failed credentials login and logs out", async () => {
@@ -137,37 +132,6 @@ describe("HomePage", () => {
     });
   });
 
-  test("falls back to email-only lookup when exact email+jwt match does not exist", async () => {
-    const loginMock = jest.fn();
-
-    global.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ token: "jwt-token" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ id: 9 }],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ id: 9 }),
-      });
-
-    renderWithContext({ demo: jest.fn(), login: loginMock, logout: jest.fn() });
-
-    submitCredentials();
-
-    await waitFor(() => {
-      expect(loginMock).toHaveBeenCalledWith(9, "user@example.com", { token: "jwt-token" });
-      expect(replaceMock).toHaveBeenCalledWith("/monitors");
-    });
-  });
-
   test("shows fetch exception when scraper login request throws", async () => {
     global.fetch.mockRejectedValueOnce(new Error("network down"));
 
@@ -195,10 +159,6 @@ describe("HomePage", () => {
         json: async () => [],
       })
       .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
-      })
-      .mockResolvedValueOnce({
         ok: false,
         text: async () => '{"message":"create failed"}',
       });
@@ -209,7 +169,7 @@ describe("HomePage", () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenNthCalledWith(
-        4,
+        3,
         "/api/user",
         expect.objectContaining({ method: "POST" }),
       );
@@ -286,10 +246,6 @@ describe("HomePage", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ token: "header.eyJlbWFpbCI6ImRlbW9AZXhhbXBsZS5jb20ifQ.signature", challenge: "demo-challenge" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,

--- a/tests/views/HomePage.test.jsx
+++ b/tests/views/HomePage.test.jsx
@@ -69,6 +69,10 @@ describe("HomePage", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ({ id: 7 }),
       });
 
@@ -81,6 +85,13 @@ describe("HomePage", () => {
       expect(replaceMock).toHaveBeenCalledWith("/monitors");
       expect(toastSuccessMock).toHaveBeenCalledWith("Login successful!");
     });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/api/user?"),
+    );
+    expect(global.fetch.mock.calls[1][0]).toContain("email=user%40example.com");
+    expect(global.fetch.mock.calls[1][0]).toContain("jwt=jwt-token");
   });
 
   test("handles failed credentials login and logs out", async () => {
@@ -126,6 +137,37 @@ describe("HomePage", () => {
     });
   });
 
+  test("falls back to email-only lookup when exact email+jwt match does not exist", async () => {
+    const loginMock = jest.fn();
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: "jwt-token" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: 9 }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 9 }),
+      });
+
+    renderWithContext({ demo: jest.fn(), login: loginMock, logout: jest.fn() });
+
+    submitCredentials();
+
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledWith(9, "user@example.com", { token: "jwt-token" });
+      expect(replaceMock).toHaveBeenCalledWith("/monitors");
+    });
+  });
+
   test("shows fetch exception when scraper login request throws", async () => {
     global.fetch.mockRejectedValueOnce(new Error("network down"));
 
@@ -153,6 +195,10 @@ describe("HomePage", () => {
         json: async () => [],
       })
       .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
         ok: false,
         text: async () => '{"message":"create failed"}',
       });
@@ -163,7 +209,7 @@ describe("HomePage", () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenNthCalledWith(
-        3,
+        4,
         "/api/user",
         expect.objectContaining({ method: "POST" }),
       );
@@ -247,6 +293,10 @@ describe("HomePage", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ({ id: 77 }),
       });
 
@@ -261,8 +311,9 @@ describe("HomePage", () => {
     await waitFor(() => {
       expect(global.fetch).toHaveBeenNthCalledWith(
         2,
-        "/api/user?email=demo@example.com",
+        expect.stringContaining("/api/user?"),
       );
+      expect(global.fetch.mock.calls[1][0]).toContain("email=demo%40example.com");
       expect(demoMock).toHaveBeenCalledWith(
         77,
         "demo@example.com",

--- a/tests/views/HomePage.test.jsx
+++ b/tests/views/HomePage.test.jsx
@@ -279,4 +279,29 @@ describe("HomePage", () => {
       expect(toastSuccessMock).toHaveBeenCalledWith("Login successful!");
     });
   });
+
+  test("fails demo login gracefully when scraper response has no token", async () => {
+    const demoMock = jest.fn();
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ challenge: "demo-challenge" }),
+    });
+
+    render(
+      <LoginContext.Provider value={{ demo: demoMock, login: jest.fn(), logout: jest.fn() }}>
+        <HomePage demoEnabled={true} initError={undefined} />
+      </LoginContext.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "see" }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("Demo login response is missing token.");
+      expect(demoMock).not.toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(replaceMock).not.toHaveBeenCalled();
+      expect(toastSuccessMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/views/HomePage.test.jsx
+++ b/tests/views/HomePage.test.jsx
@@ -232,4 +232,44 @@ describe("HomePage", () => {
       expect(toastSuccessMock).not.toHaveBeenCalled();
     });
   });
+
+  test("persists demo user and logs in demo with saved user id", async () => {
+    const demoMock = jest.fn();
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: "header.eyJlbWFpbCI6ImRlbW9AZXhhbXBsZS5jb20ifQ.signature", challenge: "demo-challenge" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 77 }),
+      });
+
+    render(
+      <LoginContext.Provider value={{ demo: demoMock, login: jest.fn(), logout: jest.fn() }}>
+        <HomePage demoEnabled={true} initError={undefined} />
+      </LoginContext.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "see" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        "/api/user?email=demo@example.com",
+      );
+      expect(demoMock).toHaveBeenCalledWith(
+        77,
+        "demo@example.com",
+        expect.objectContaining({ token: expect.any(String) }),
+      );
+      expect(replaceMock).toHaveBeenCalledWith("/monitors");
+      expect(toastSuccessMock).toHaveBeenCalledWith("Login successful!");
+    });
+  });
 });

--- a/tests/views/NotifiersPage.test.jsx
+++ b/tests/views/NotifiersPage.test.jsx
@@ -39,13 +39,27 @@ describe("NotifiersPage", () => {
     global.fetch = originalFetch;
   });
 
-  function renderWithLogin({ userIdValue = 1, token = "token-1" } = {}) {
+  function renderWithLogin({ userIdValue = 1, token = "token-1", isDemo = false } = {}) {
     return render(
-      <LoginContext.Provider value={{ userId: () => userIdValue, token }}>
+      <LoginContext.Provider value={{ isDemo, userId: () => userIdValue, token }}>
         <NotifiersPage />
       </LoginContext.Provider>,
     );
   }
+
+  test("fetches notifiers in demo mode using regular auth flow", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    renderWithLogin({ userIdValue: 7357, token: "demo-token", isDemo: true });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("button", { name: "add" })).not.toBeDisabled();
+    });
+  });
 
   test("shows error when user id is missing", async () => {
     renderWithLogin({ userIdValue: "", token: "token-1" });


### PR DESCRIPTION
This patch fixes #106 
Now demo user is correctly retrieved, saved when starting demo session and deleted while stopping session. Also regular and demo sessions is differentiated based on explicit settings, not hardcoded user id.