### PR TITLE
Added Swagger UI documentation link to page header

### DIFF
--- a/src/app/api/docs/openapi.json/route.js
+++ b/src/app/api/docs/openapi.json/route.js
@@ -49,7 +49,7 @@ export async function GET(request) {
       message: `Cannot load OpenAPI specification: ${OpenApiBundler.getErrorMessage(error)}`,
     };
     return new Response(JSON.stringify(output), {
-      status: RequestUtils.getErrorStatus(error),
+      status: RequestUtils.getErrorStatus(error, 500),
       headers: {
         "Content-Type": "application/json; charset=utf-8",
         "Cache-Control": "no-store",

--- a/src/app/api/docs/openapi.json/route.js
+++ b/src/app/api/docs/openapi.json/route.js
@@ -45,11 +45,15 @@ export async function GET(request) {
       },
     });
   } catch (error) {
+    const status = RequestUtils.getErrorStatus(error, 500);
+    const isAuthOrValidationError = status === 400 || status === 401 || status === 403;
     const output = {
-      message: `Cannot load OpenAPI specification: ${OpenApiBundler.getErrorMessage(error)}`,
+      message: isAuthOrValidationError
+        ? OpenApiBundler.getErrorMessage(error)
+        : `Cannot load OpenAPI specification: ${OpenApiBundler.getErrorMessage(error)}`,
     };
     return new Response(JSON.stringify(output), {
-      status: RequestUtils.getErrorStatus(error, 500),
+      status,
       headers: {
         "Content-Type": "application/json; charset=utf-8",
         "Cache-Control": "no-store",

--- a/src/app/api/docs/openapi.json/route.js
+++ b/src/app/api/docs/openapi.json/route.js
@@ -1,5 +1,7 @@
 import path from "node:path";
 import { OpenApiBundler } from "@/lib/OpenApiBundler";
+import { authorizeUser } from "@/lib/ApiUserAuth";
+import { RequestUtils } from "@/lib/RequestUtils";
 
 export const runtime = "nodejs";
 
@@ -30,8 +32,10 @@ async function getBundledOpenApiDocument() {
   return pendingBundlePromise;
 }
 
-export async function GET() {
+export async function GET(request) {
   try {
+    const user = request.nextUrl.searchParams.get("user");
+    await authorizeUser(request, user);
     const openApiDocument = await getBundledOpenApiDocument();
     return new Response(JSON.stringify(openApiDocument, null, 2), {
       status: 200,
@@ -45,7 +49,7 @@ export async function GET() {
       message: `Cannot load OpenAPI specification: ${OpenApiBundler.getErrorMessage(error)}`,
     };
     return new Response(JSON.stringify(output), {
-      status: 500,
+      status: RequestUtils.getErrorStatus(error),
       headers: {
         "Content-Type": "application/json; charset=utf-8",
         "Cache-Control": "no-store",

--- a/src/app/api/docs/page.js
+++ b/src/app/api/docs/page.js
@@ -1,5 +1,6 @@
 import SwaggerDocs from "@/components/SwaggerDocs";
 import ScrollHintContainer from "@/components/ScrollHintContainer";
+import UserAccess from "@/components/UserAccess";
 
 export const metadata = {
   title: "API docs | data-monitor",
@@ -8,8 +9,10 @@ export const metadata = {
 
 export default function ApiDocsPage() {
   return (
-    <ScrollHintContainer className="api-docs-page" hintText="More content below, scroll down" hideScrollbar>
-      <SwaggerDocs />
-    </ScrollHintContainer>
+    <UserAccess>
+      <ScrollHintContainer className="api-docs-page" hintText="More content below, scroll down" hideScrollbar>
+        <SwaggerDocs />
+      </ScrollHintContainer>
+    </UserAccess>
   );
 }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -41,6 +41,10 @@ div.page-head-logo-div {
   @apply flex w-full sm:w-[80%] mt-2 sm:mt-5 mb-2 sm:mb-5;
 }
 
+div.page-head-logo-unit {
+  @apply flex flex-shrink-0 items-center ml-1 sm:ml-0;
+}
+
 div.page-head-menu-div {
   @apply flex items-center justify-evenly sm:justify-end flex-row;
   @apply w-full sm:w-[80%] mb-2;
@@ -48,7 +52,11 @@ div.page-head-menu-div {
 }
 
 a.page-head-logo-link {
-  @apply flex flex-shrink-0 items-center ml-1 sm:ml-0;
+  @apply flex flex-shrink-0 items-center;
+}
+
+a.page-head-logo-title-link {
+  @apply text-inherit no-underline;
 }
 
 img.page-head-logo-img {
@@ -59,12 +67,26 @@ span.page-head-logo-text-wrap {
   @apply flex flex-col ml-2 leading-tight;
 }
 
+span.page-head-logo-meta {
+  @apply flex items-center gap-x-1;
+}
+
 span.page-head-logo-text {
   @apply md:block text-white text-2xl font-bold;
 }
 
 span.page-head-logo-version {
   @apply text-indigo-100 text-[0.62rem] sm:text-xs font-medium tracking-wide;
+}
+
+span.page-head-logo-separator {
+  @apply text-indigo-200 text-[0.62rem] sm:text-xs;
+}
+
+a.page-head-logo-docs-link {
+  @apply text-indigo-100 text-[0.62rem] sm:text-xs font-semibold tracking-wide;
+  @apply underline-offset-2 hover:underline rounded-sm;
+  @apply focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-100;
 }
 
 section.menu-section {

--- a/src/components/MenuBar.jsx
+++ b/src/components/MenuBar.jsx
@@ -79,7 +79,7 @@ const MenuBar = () => {
           </form>
         </section>
       )}
-      {"notifiers" === pageId && (
+      {("notifiers" === pageId || "docs" === pageId) && (
         <section className="menu-section">
           <form className="menu-item-form" onSubmit={viewMonitors}>
             <div className="menu-item-div">
@@ -90,7 +90,7 @@ const MenuBar = () => {
           </form>
         </section>
       )}
-      {config.scraper.public && challenge && (
+      {config.scraper.public && challenge && "docs" !== pageId && (
         <section className="menu-section">
           <form className="menu-item-form" onSubmit={viewConfig}>
             <div className="menu-item-div">

--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -13,13 +13,25 @@ const PageHeader = ({ appVersion }) => {
   return (
     <nav className="page-head">
       <div className="page-head-logo-div">
-        <Link className="page-head-logo-link" href="/" title={appVersion}>
-          <Image className="page-head-logo-img" src={logo} alt="data-monitor logo" />
+        <div className="page-head-logo-unit">
+          <Link className="page-head-logo-link" href="/" title={appVersion}>
+            <Image className="page-head-logo-img" src={logo} alt="data-monitor logo" />
+          </Link>
           <span className="page-head-logo-text-wrap">
-            <span className="page-head-logo-text">data-monitor</span>
-            <span className="page-head-logo-version">{appVersion}</span>
+            <Link className="page-head-logo-title-link" href="/" title={appVersion}>
+              <span className="page-head-logo-text">data-monitor</span>
+            </Link>
+            <span className="page-head-logo-meta">
+              <span className="page-head-logo-version">{appVersion}</span>
+              <span className="page-head-logo-separator" aria-hidden="true">
+                |
+              </span>
+              <Link className="page-head-logo-docs-link" href="/api/docs" title="Open API docs">
+                docs
+              </Link>
+            </span>
           </span>
-        </Link>
+        </div>
       </div>
       {userLogged && <MenuBar />}
     </nav>

--- a/src/components/SwaggerDocs.jsx
+++ b/src/components/SwaggerDocs.jsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useContext, useEffect, useRef } from "react";
 import SwaggerUIBundle from "swagger-ui-dist/swagger-ui-es-bundle";
 import SwaggerUIStandalonePreset from "swagger-ui-dist/swagger-ui-standalone-preset";
+import { PageContext } from "@/context/Contexts";
 
 function initializeSwaggerUi() {
   if ("undefined" === typeof window) return;
@@ -24,6 +25,11 @@ function initializeSwaggerUi() {
 
 export default function SwaggerDocs() {
   const swaggerUiRef = useRef(null);
+  const { setPageId } = useContext(PageContext);
+
+  useEffect(() => {
+    setPageId("docs");
+  }, [setPageId]);
 
   useEffect(() => {
     swaggerUiRef.current = initializeSwaggerUi();

--- a/src/components/SwaggerDocs.jsx
+++ b/src/components/SwaggerDocs.jsx
@@ -36,13 +36,14 @@ export default function SwaggerDocs() {
   const swaggerUiRef = useRef(null);
   const { setPageId } = useContext(PageContext);
   const { token, userId } = useContext(LoginContext);
+  const resolvedUserId = typeof userId === "function" ? userId() : null;
 
   useEffect(() => {
     setPageId("docs");
   }, [setPageId]);
 
   useEffect(() => {
-    swaggerUiRef.current = initializeSwaggerUi(token, userId());
+    swaggerUiRef.current = initializeSwaggerUi(token, resolvedUserId);
 
     return () => {
       if (typeof swaggerUiRef.current?.destroy === "function") {
@@ -50,7 +51,7 @@ export default function SwaggerDocs() {
       }
       swaggerUiRef.current = null;
     };
-  }, [token, userId]);
+  }, [token, resolvedUserId]);
 
   return <div id="swagger-ui" />;
 }

--- a/src/components/SwaggerDocs.jsx
+++ b/src/components/SwaggerDocs.jsx
@@ -3,21 +3,30 @@
 import { useContext, useEffect, useRef } from "react";
 import SwaggerUIBundle from "swagger-ui-dist/swagger-ui-es-bundle";
 import SwaggerUIStandalonePreset from "swagger-ui-dist/swagger-ui-standalone-preset";
-import { PageContext } from "@/context/Contexts";
+import { LoginContext, PageContext } from "@/context/Contexts";
 
-function initializeSwaggerUi() {
+function initializeSwaggerUi(token, userId) {
   if ("undefined" === typeof window) return;
   const rootElement = window.document.getElementById("swagger-ui");
   if (rootElement == null) return;
 
   return SwaggerUIBundle({
-    url: "/api/docs/openapi.json",
+    url: `/api/docs/openapi.json?user=${encodeURIComponent(String(userId ?? ""))}`,
     dom_id: "#swagger-ui",
     deepLinking: true,
     docExpansion: "list",
     displayRequestDuration: true,
     filter: true,
     supportedSubmitMethods: [],
+    requestInterceptor: (req) => {
+      if (token) {
+        req.headers = {
+          ...(req.headers || {}),
+          Authorization: `Bearer ${token}`,
+        };
+      }
+      return req;
+    },
     presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
     layout: "BaseLayout",
   });
@@ -26,13 +35,14 @@ function initializeSwaggerUi() {
 export default function SwaggerDocs() {
   const swaggerUiRef = useRef(null);
   const { setPageId } = useContext(PageContext);
+  const { token, userId } = useContext(LoginContext);
 
   useEffect(() => {
     setPageId("docs");
   }, [setPageId]);
 
   useEffect(() => {
-    swaggerUiRef.current = initializeSwaggerUi();
+    swaggerUiRef.current = initializeSwaggerUi(token, userId());
 
     return () => {
       if (typeof swaggerUiRef.current?.destroy === "function") {
@@ -40,7 +50,7 @@ export default function SwaggerDocs() {
       }
       swaggerUiRef.current = null;
     };
-  }, []);
+  }, [token, userId]);
 
   return <div id="swagger-ui" />;
 }

--- a/tests/app/api/docs/openapi.json/route.test.js
+++ b/tests/app/api/docs/openapi.json/route.test.js
@@ -97,4 +97,16 @@ describe("app/api/docs/openapi.json route", () => {
     expect(response.status).toBe(500);
     expect(body.message).toBe("Cannot load OpenAPI specification: Unknown error");
   });
+
+  test("GET returns auth error message directly for authorization failures", async () => {
+    const error = new Error("Missing or invalid authorization header.");
+    error.status = 401;
+    authorizeUser.mockRejectedValueOnce(error);
+
+    const response = await GET(reqWithUrl("http://test/api/docs/openapi.json?user=1"));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.message).toBe("Missing or invalid authorization header.");
+  });
 });

--- a/tests/app/api/docs/openapi.json/route.test.js
+++ b/tests/app/api/docs/openapi.json/route.test.js
@@ -7,9 +7,19 @@ jest.mock("node:fs/promises", () => ({
 }));
 
 import fs from "node:fs/promises";
+import { authorizeUser } from "@/lib/ApiUserAuth";
 import { GET } from "../../../../../src/app/api/docs/openapi.json/route.js";
 
+jest.mock("@/lib/ApiUserAuth", () => ({ authorizeUser: jest.fn() }));
+
 const mockReadFile = fs.readFile;
+
+const reqWithUrl = (url) => ({
+  nextUrl: new URL(url),
+  headers: {
+    get: jest.fn(() => null),
+  },
+});
 
 class MockResponse {
   constructor(body, init = {}) {
@@ -46,6 +56,7 @@ describe("app/api/docs/openapi.json route", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    authorizeUser.mockResolvedValue(1);
   });
 
   test("GET returns bundled OpenAPI document", async () => {
@@ -58,7 +69,7 @@ describe("app/api/docs/openapi.json route", () => {
       })
     );
 
-    const response = await GET();
+    const response = await GET(reqWithUrl("http://test/api/docs/openapi.json?user=1"));
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -69,7 +80,7 @@ describe("app/api/docs/openapi.json route", () => {
   test("GET returns 500 with stable error payload when OpenAPI cannot be parsed", async () => {
     mockReadFile.mockResolvedValueOnce("{ invalid-json }");
 
-    const response = await GET();
+    const response = await GET(reqWithUrl("http://test/api/docs/openapi.json?user=1"));
     const body = await response.json();
 
     expect(response.status).toBe(500);
@@ -80,7 +91,7 @@ describe("app/api/docs/openapi.json route", () => {
   test("GET normalizes non-Error thrown values", async () => {
     mockReadFile.mockRejectedValueOnce(null);
 
-    const response = await GET();
+    const response = await GET(reqWithUrl("http://test/api/docs/openapi.json?user=1"));
     const body = await response.json();
 
     expect(response.status).toBe(500);

--- a/tests/components/SwaggerDocs.test.jsx
+++ b/tests/components/SwaggerDocs.test.jsx
@@ -14,6 +14,7 @@ jest.mock("swagger-ui-dist/swagger-ui-standalone-preset", () => ({
 
 import SwaggerUIBundle from "swagger-ui-dist/swagger-ui-es-bundle";
 import SwaggerDocs from "../../src/components/SwaggerDocs.jsx";
+import { LoginContext, PageContext } from "../../src/context/Contexts.jsx";
 
 describe("SwaggerDocs", () => {
   beforeEach(() => {
@@ -21,19 +22,26 @@ describe("SwaggerDocs", () => {
   });
 
   test("initializes Swagger UI and disposes instance on unmount", () => {
+    const setPageId = jest.fn();
     const { unmount } = render(
-      <section className="api-docs-page">
-        <SwaggerDocs />
-      </section>
+      <LoginContext.Provider value={{ token: "abc-token", userId: () => 7 }}>
+        <PageContext.Provider value={{ setPageId }}>
+          <section className="api-docs-page">
+            <SwaggerDocs />
+          </section>
+        </PageContext.Provider>
+      </LoginContext.Provider>
     );
 
     expect(SwaggerUIBundle).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "/api/docs/openapi.json",
+        url: "/api/docs/openapi.json?user=7",
         dom_id: "#swagger-ui",
         supportedSubmitMethods: [],
       })
     );
+
+    expect(setPageId).toHaveBeenCalledWith("docs");
 
     const swaggerUiInstance = SwaggerUIBundle.mock.results[0].value;
 


### PR DESCRIPTION
This patch fixes #110 
Now a "docs" link is available after version string in page header for easier navigation. Also I've safeguarded docs UI and JSON access only to logged users + defined which menu buttons should be visible in docs page.