### PR TITLE
Updated user API endpoints to required bearer token

### DIFF
--- a/openapi/paths/api-user.json
+++ b/openapi/paths/api-user.json
@@ -3,12 +3,19 @@
     "tags": [
       "users"
     ],
-    "summary": "List or filter users",
+    "summary": "Filter users for authorized session",
+    "description": "Requires bearer authentication. Query must include either id or email. When email is used, results are restricted to the authenticated token owner.",
     "operationId": "getUsers",
+    "security": [
+      {
+        "bearerAuth": []
+      }
+    ],
     "parameters": [
       {
         "name": "id",
         "in": "query",
+        "description": "User id to retrieve. Must belong to authenticated session.",
         "schema": {
           "type": "integer",
           "minimum": 1
@@ -17,18 +24,11 @@
       {
         "name": "email",
         "in": "query",
+        "description": "User email to retrieve for authenticated token.",
         "schema": {
           "type": "string",
           "format": "email"
         }
-      },
-      {
-        "name": "jwt",
-        "in": "query",
-        "schema": {
-          "type": "string"
-        },
-        "description": "Used only with indexed filters by current implementation."
       }
     ],
     "responses": {
@@ -47,6 +47,12 @@
       },
       "400": {
         "$ref": "#/components/responses/BadRequest"
+      },
+      "401": {
+        "$ref": "#/components/responses/Unauthorized"
+      },
+      "403": {
+        "$ref": "#/components/responses/Forbidden"
       }
     }
   },
@@ -54,8 +60,14 @@
     "tags": [
       "users"
     ],
-    "summary": "Create user",
+    "summary": "Create or refresh user session",
+    "description": "Requires bearer authentication. Request body jwt must match bearer token. If email already exists, jwt is refreshed for that user.",
     "operationId": "createUser",
+    "security": [
+      {
+        "bearerAuth": []
+      }
+    ],
     "requestBody": {
       "required": true,
       "content": {
@@ -79,6 +91,12 @@
       },
       "400": {
         "$ref": "#/components/responses/BadRequest"
+      },
+      "401": {
+        "$ref": "#/components/responses/Unauthorized"
+      },
+      "403": {
+        "$ref": "#/components/responses/Forbidden"
       }
     }
   },
@@ -88,6 +106,11 @@
     ],
     "summary": "Update user by id",
     "operationId": "updateUser",
+    "security": [
+      {
+        "bearerAuth": []
+      }
+    ],
     "parameters": [
       {
         "$ref": "#/components/parameters/IdQuery"
@@ -116,6 +139,15 @@
       },
       "400": {
         "$ref": "#/components/responses/BadRequest"
+      },
+      "401": {
+        "$ref": "#/components/responses/Unauthorized"
+      },
+      "403": {
+        "$ref": "#/components/responses/Forbidden"
+      },
+      "404": {
+        "$ref": "#/components/responses/NotFound"
       }
     }
   },
@@ -125,6 +157,11 @@
     ],
     "summary": "Delete user by id",
     "operationId": "deleteUser",
+    "security": [
+      {
+        "bearerAuth": []
+      }
+    ],
     "parameters": [
       {
         "$ref": "#/components/parameters/IdQuery"
@@ -143,6 +180,12 @@
       },
       "400": {
         "$ref": "#/components/responses/BadRequest"
+      },
+      "401": {
+        "$ref": "#/components/responses/Unauthorized"
+      },
+      "403": {
+        "$ref": "#/components/responses/Forbidden"
       }
     }
   }

--- a/openapi/paths/api-user.json
+++ b/openapi/paths/api-user.json
@@ -61,7 +61,7 @@
       "users"
     ],
     "summary": "Create or refresh user session",
-    "description": "Requires bearer authentication. Request body jwt must match bearer token. If email already exists, jwt is refreshed for that user.",
+    "description": "Requires bearer authentication. Request body jwt must match bearer token. Token email claim must match request email and token must be accepted by scraper backend. If email already exists, jwt is refreshed for that user.",
     "operationId": "createUser",
     "security": [
       {
@@ -97,6 +97,9 @@
       },
       "403": {
         "$ref": "#/components/responses/Forbidden"
+      },
+      "503": {
+        "$ref": "#/components/responses/ServerError"
       }
     }
   },

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -50,7 +50,13 @@ function validateUserJwt(value) {
  */
 function normalizeUserFilters(searchParams) {
   const id = searchParams.get("id");
-  const email = sanitizeUserEmail(searchParams.get("email"));
+  const rawEmail = searchParams.get("email");
+  const email = sanitizeUserEmail(rawEmail);
+  if (searchParams.has("email") && !email) {
+    const error = new Error("Invalid user email filter.");
+    error.status = 400;
+    throw error;
+  }
   return {
     ...(id && { id }),
     ...(email && { email }),
@@ -91,13 +97,13 @@ function normalizeUserInput(user, options = {}) {
   }
   const requireEmail = options.requireEmail === true;
   const sanitizedEmail = user.email != null ? sanitizeUserEmail(user.email) : "";
-  if (requireEmail && !sanitizedEmail) {
-    const error = new Error("User email is required.");
+  if (user.email != null && !sanitizedEmail) {
+    const error = new Error("Invalid user email.");
     error.status = 400;
     throw error;
   }
-  if (user.email != null && !sanitizedEmail) {
-    const error = new Error("Invalid user email.");
+  if (requireEmail && !sanitizedEmail) {
+    const error = new Error("User email is required.");
     error.status = 400;
     throw error;
   }
@@ -180,7 +186,7 @@ export async function PUT(request) {
     const searchParams = request.nextUrl.searchParams;
     const id = searchParams.get("id");
     const authorizedUserId = await authorizeUser(request, id);
-    const userData = normalizeUserInput(await request.json(), { requireEmail: false, requireJwt: false });
+    const userData = normalizeUserInput(await request.json(), { requireEmail: true, requireJwt: false });
     const user = await UserService.editUser(authorizedUserId, userData);
     if (user == null) {
       const error = new Error("User not found.");

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -1,5 +1,8 @@
 import { UserService } from "@/model/UserService";
 import { authorizeUser, requireBearerToken } from "@/lib/ApiUserAuth";
+import { getEmailFromJwt } from "@/lib/AuthTokenUtils";
+import { ScraperRequest } from "@/lib/ScraperRequest";
+import { AppConfig } from "@/config/AppConfig";
 import { DataSanitizer } from "@/lib/DataSanitizer";
 import { RequestUtils } from "@/lib/RequestUtils";
 
@@ -129,6 +132,34 @@ function getSafeUser(user) {
   };
 }
 
+/**
+ * Method used to verify that provided token belongs to provided email and is accepted by scraper backend
+ * @param {String} token Bearer token value
+ * @param {String} expectedEmail Sanitized email expected for token owner
+ */
+async function assertAuthorizedTokenForEmail(token, expectedEmail) {
+  const tokenEmail = sanitizeUserEmail(getEmailFromJwt(token));
+  if (!tokenEmail || tokenEmail !== expectedEmail) {
+    const error = new Error("User authorization failed.");
+    error.status = 403;
+    throw error;
+  }
+
+  const validateTokenResponse = await ScraperRequest.GET(
+    AppConfig.getConfig().scraper.endpoints.data,
+    { Authorization: `Bearer ${token}` },
+  );
+  if (!validateTokenResponse.ok) {
+    const error = new Error(
+      validateTokenResponse.status >= 500
+        ? "Cannot validate user token with scraper backend."
+        : "User authorization failed.",
+    );
+    error.status = validateTokenResponse.status >= 500 ? 503 : 403;
+    throw error;
+  }
+}
+
 export async function GET(request) {
   try {
     const searchParams = request.nextUrl.searchParams;
@@ -167,6 +198,7 @@ export async function POST(request) {
       error.status = 403;
       throw error;
     }
+    await assertAuthorizedTokenForEmail(token, userData.email);
     const user = await UserService.addUser(userData);
     return new Response(JSON.stringify(getSafeUser(user)), {
       status: 200,

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -7,6 +7,7 @@ import { DataSanitizer } from "@/lib/DataSanitizer";
 import { RequestUtils } from "@/lib/RequestUtils";
 
 const PRIVATE_PLACEHOLDER = "PRIVATE";
+const TOKEN_VALIDATION_PROBE_ITEM = "__token_validation_probe__";
 
 /**
  * Method used to normalize placeholder values before persisting sensitive fields
@@ -93,11 +94,6 @@ function normalizeUserInput(user, options = {}) {
     error.status = 400;
     throw error;
   }
-  if (user.jwt != null && normalizedJwt !== "" && !sanitizedJwt) {
-    const error = new Error("Invalid user JWT.");
-    error.status = 400;
-    throw error;
-  }
   const requireEmail = options.requireEmail === true;
   const sanitizedEmail = user.email != null ? sanitizeUserEmail(user.email) : "";
   if (user.email != null && !sanitizedEmail) {
@@ -146,7 +142,7 @@ async function assertAuthorizedTokenForEmail(token, expectedEmail) {
   }
 
   const validateTokenResponse = await ScraperRequest.GET(
-    AppConfig.getConfig().scraper.endpoints.data,
+    `${AppConfig.getConfig().scraper.endpoints.items}?name=${encodeURIComponent(TOKEN_VALIDATION_PROBE_ITEM)}`,
     { Authorization: `Bearer ${token}` },
   );
   if (!validateTokenResponse.ok) {

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -1,5 +1,5 @@
 import { UserService } from "@/model/UserService";
-import { authorizeUser } from "@/lib/ApiUserAuth";
+import { authorizeUser, requireBearerToken } from "@/lib/ApiUserAuth";
 import { DataSanitizer } from "@/lib/DataSanitizer";
 import { RequestUtils } from "@/lib/RequestUtils";
 
@@ -41,35 +41,6 @@ function validateUserJwt(value) {
     throw error;
   }
   return input;
-}
-
-/**
- * Method used to parse bearer token from request authorization header
- * @param {Object} request Request object received from frontend
- * @returns token string when present, otherwise null
- */
-function getBearerToken(request) {
-  const authorizationHeader = request.headers?.get("authorization") || "";
-  if (!authorizationHeader.toLowerCase().startsWith("bearer ")) {
-    return null;
-  }
-  const token = authorizationHeader.substring(7).trim();
-  return token === "" ? null : token;
-}
-
-/**
- * Method used to verify bearer token availability in request
- * @param {Object} request Request object received from frontend
- * @returns bearer token string
- */
-function requireBearerToken(request) {
-  const token = getBearerToken(request);
-  if (token == null) {
-    const error = new Error("Missing or invalid authorization header.");
-    error.status = 401;
-    throw error;
-  }
-  return token;
 }
 
 /**

--- a/src/app/api/user/route.js
+++ b/src/app/api/user/route.js
@@ -1,4 +1,5 @@
 import { UserService } from "@/model/UserService";
+import { authorizeUser } from "@/lib/ApiUserAuth";
 import { DataSanitizer } from "@/lib/DataSanitizer";
 import { RequestUtils } from "@/lib/RequestUtils";
 
@@ -43,6 +44,35 @@ function validateUserJwt(value) {
 }
 
 /**
+ * Method used to parse bearer token from request authorization header
+ * @param {Object} request Request object received from frontend
+ * @returns token string when present, otherwise null
+ */
+function getBearerToken(request) {
+  const authorizationHeader = request.headers?.get("authorization") || "";
+  if (!authorizationHeader.toLowerCase().startsWith("bearer ")) {
+    return null;
+  }
+  const token = authorizationHeader.substring(7).trim();
+  return token === "" ? null : token;
+}
+
+/**
+ * Method used to verify bearer token availability in request
+ * @param {Object} request Request object received from frontend
+ * @returns bearer token string
+ */
+function requireBearerToken(request) {
+  const token = getBearerToken(request);
+  if (token == null) {
+    const error = new Error("Missing or invalid authorization header.");
+    error.status = 401;
+    throw error;
+  }
+  return token;
+}
+
+/**
  * Method used to normalize GET query filters for user route
  * @param {URLSearchParams} searchParams User query parameters
  * @returns normalized filter object
@@ -50,12 +80,9 @@ function validateUserJwt(value) {
 function normalizeUserFilters(searchParams) {
   const id = searchParams.get("id");
   const email = sanitizeUserEmail(searchParams.get("email"));
-  const jwt = validateUserJwt(searchParams.get("jwt"));
-  const hasIndexedFilter = Boolean(id || email);
   return {
     ...(id && { id }),
     ...(email && { email }),
-    ...(hasIndexedFilter && jwt && { jwt }),
   };
 }
 
@@ -69,7 +96,14 @@ function normalizeUserFilters(searchParams) {
  */
 function normalizeUserInput(user, options = {}) {
   if (user == null) {
-    return user;
+    const error = new Error("Invalid user payload.");
+    error.status = 400;
+    throw error;
+  }
+  if (typeof user !== "object") {
+    const error = new Error("Invalid user payload.");
+    error.status = 400;
+    throw error;
   }
   const requireJwt = options.requireJwt === true;
   const normalizedJwt = normalizeSensitiveInput(user.jwt);
@@ -121,16 +155,19 @@ function getSafeUser(user) {
 export async function GET(request) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    if (0 === searchParams.size) {
-      const users = await UserService.getUsers();
-      return new Response(JSON.stringify(users.map((user) => getSafeUser(user))), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+    const filters = normalizeUserFilters(searchParams);
+    if (filters.id) {
+      const authorizedUserId = await authorizeUser(request, filters.id);
+      filters.id = String(authorizedUserId);
+    } else if (filters.email) {
+      const token = requireBearerToken(request);
+      filters.jwt = validateUserJwt(token);
+    } else {
+      const error = new Error("User GET requires either 'id' or 'email' filter.");
+      error.status = 400;
+      throw error;
     }
-    const users = await UserService.filterUsers({
-      ...normalizeUserFilters(searchParams),
-    });
+    const users = await UserService.filterUsers(filters);
     return new Response(JSON.stringify(users.map((user) => getSafeUser(user))), {
       status: 200,
       headers: { "Content-Type": "application/json" },
@@ -147,6 +184,12 @@ export async function GET(request) {
 export async function POST(request) {
   try {
     const userData = normalizeUserInput(await request.json(), { requireEmail: true, requireJwt: true });
+    const token = requireBearerToken(request);
+    if (token !== userData.jwt) {
+      const error = new Error("User authorization failed.");
+      error.status = 403;
+      throw error;
+    }
     const user = await UserService.addUser(userData);
     return new Response(JSON.stringify(getSafeUser(user)), {
       status: 200,
@@ -165,8 +208,14 @@ export async function PUT(request) {
   try {
     const searchParams = request.nextUrl.searchParams;
     const id = searchParams.get("id");
+    const authorizedUserId = await authorizeUser(request, id);
     const userData = normalizeUserInput(await request.json(), { requireEmail: false, requireJwt: false });
-    const user = await UserService.editUser(id, userData);
+    const user = await UserService.editUser(authorizedUserId, userData);
+    if (user == null) {
+      const error = new Error("User not found.");
+      error.status = 404;
+      throw error;
+    }
     return new Response(JSON.stringify(getSafeUser(user)), {
       status: 200,
       headers: { "Content-Type": "application/json" },
@@ -184,7 +233,8 @@ export async function DELETE(request) {
   try {
     const searchParams = request.nextUrl.searchParams;
     const id = searchParams.get("id");
-    const deletedNo = await UserService.deleteUser(id);
+    const authorizedUserId = await authorizeUser(request, id);
+    const deletedNo = await UserService.deleteUser(authorizedUserId);
     const response = { message: `Deleted ${deletedNo} user(s)` };
     return new Response(JSON.stringify(response), {
       status: 200,

--- a/src/components/MenuBar.jsx
+++ b/src/components/MenuBar.jsx
@@ -45,6 +45,9 @@ const MenuBar = () => {
     if (currentUserId == null) {
       return { ok: false, cause: "Invalid user ID" };
     }
+    if (token == null || String(token).trim() === "") {
+      return { ok: false, cause: "Missing user token" };
+    }
     const cleanupResponse = await fetch(`/api/user?id=${currentUserId}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${token}` },

--- a/src/components/MenuBar.jsx
+++ b/src/components/MenuBar.jsx
@@ -9,7 +9,7 @@ import { LoginContext, PageContext } from "@/context/Contexts";
 const MenuBar = () => {
   const config = AppConfig.getConfig();
   const router = useRouter();
-  const { isDemo, challenge, logout, userId } = useContext(LoginContext);
+  const { isDemo, challenge, logout, userId, token } = useContext(LoginContext);
   const { pageId } = useContext(PageContext);
 
   const getValidUserId = () => {
@@ -47,6 +47,7 @@ const MenuBar = () => {
     }
     const cleanupResponse = await fetch(`/api/user?id=${currentUserId}`, {
       method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
     });
     if (!cleanupResponse.ok) {
       return { ok: false, cause: "Cannot remove demo user" };

--- a/src/lib/ApiUserAuth.js
+++ b/src/lib/ApiUserAuth.js
@@ -5,13 +5,28 @@ import { UserService } from "@/model/UserService";
  * @param {Object} request Request object received from frontend
  * @returns token string if present, otherwise null
  */
-function getBearerToken(request) {
+export function getBearerToken(request) {
   const authorizationHeader = request.headers.get("authorization") || "";
   if (!authorizationHeader.toLowerCase().startsWith("bearer ")) {
     return null;
   }
   const token = authorizationHeader.substring(7).trim();
   return token === "" ? null : token;
+}
+
+/**
+ * Method used to require bearer token from request authorization header
+ * @param {Object} request Request object received from frontend
+ * @returns token string
+ */
+export function requireBearerToken(request) {
+  const token = getBearerToken(request);
+  if (token == null) {
+    const error = new Error("Missing or invalid authorization header.");
+    error.status = 401;
+    throw error;
+  }
+  return token;
 }
 
 /**
@@ -37,12 +52,7 @@ function parseUserId(userInput) {
  */
 export async function authorizeUser(request, userInput) {
   const userId = parseUserId(userInput);
-  const token = getBearerToken(request);
-  if (token == null) {
-    const error = new Error("Missing or invalid authorization header.");
-    error.status = 401;
-    throw error;
-  }
+  const token = requireBearerToken(request);
   const users = await UserService.filterUsers({ id: userId, jwt: token });
   if (users.length !== 1) {
     const error = new Error("User authorization failed.");

--- a/src/model/UserService.js
+++ b/src/model/UserService.js
@@ -111,7 +111,7 @@ export class UserService {
    */
   static async deleteUser(id) {
     const { rowCount } = await DatabaseQuery(`DELETE FROM ${UserService.#DB_TABLE_NAME} WHERE id = $1`, [id]);
-    return rowCount > 0;
+    return rowCount;
   }
 
   /**

--- a/src/model/UserService.js
+++ b/src/model/UserService.js
@@ -65,15 +65,19 @@ export class UserService {
   }
 
   /**
-   * Method used to add provided user data to database
-   * @param {Object} data user object which we want to add to database
-   * @returns added user object
+   * Method used to add provided user data to database or update jwt when user email already exists
+   * @param {Object} data user object containing email and jwt values
+   * @returns added or updated user object
    */
   static async addUser(data) {
     const { email, jwt } = data;
     const encryptedJwt = DataCrypto.encrypt(jwt);
     const { rows } = await DatabaseQuery(
-      `INSERT INTO ${UserService.#DB_TABLE_NAME} (email, jwt) VALUES ($1, $2) RETURNING *`,
+      `INSERT INTO ${UserService.#DB_TABLE_NAME} (email, jwt)
+       VALUES ($1, $2)
+       ON CONFLICT (email)
+       DO UPDATE SET jwt = EXCLUDED.jwt
+       RETURNING *`,
       [email, encryptedJwt]
     );
     return UserService.#toPublicUser(rows[0]);

--- a/src/views/HomePage.jsx
+++ b/src/views/HomePage.jsx
@@ -19,9 +19,14 @@ export default function HomePage({ demoEnabled, initError }) {
     }
   }, [initError]);
 
+  const getAuthHeaders = (jwt) => ({
+    Authorization: `Bearer ${jwt}`,
+  });
+
   const userSave = async (userData) => {
+    const authHeaders = getAuthHeaders(userData.jwt);
     const getEmailUserUrl = RequestUtils.buildUrl("/api/user", { email: userData.email });
-    const getEmailUserResponse = await fetch(getEmailUserUrl);
+    const getEmailUserResponse = await fetch(getEmailUserUrl, { headers: authHeaders });
     if (!getEmailUserResponse.ok) {
       return { id: undefined, message: await RequestUtils.getResponseMessage(getEmailUserResponse) };
     }
@@ -34,7 +39,7 @@ export default function HomePage({ demoEnabled, initError }) {
     const idFilter = exists ? `?id=${existingUser.id}` : ``;
     const addUserResponse = await fetch(`/api/user${idFilter}`, {
       method: exists ? "PUT" : "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders },
       body: JSON.stringify(userData),
     });
     if (!addUserResponse.ok) {

--- a/tests/app/api/user/route.test.js
+++ b/tests/app/api/user/route.test.js
@@ -1,5 +1,6 @@
 import { GET, POST, PUT, DELETE } from "../../../../src/app/api/user/route.js";
 import { UserService } from "@/model/UserService";
+import { authorizeUser } from "@/lib/ApiUserAuth";
 import { RequestUtils } from "@/lib/RequestUtils";
 
 jest.mock("@/model/UserService", () => ({
@@ -11,6 +12,7 @@ jest.mock("@/model/UserService", () => ({
     deleteUser: jest.fn(),
   },
 }));
+jest.mock("@/lib/ApiUserAuth", () => ({ authorizeUser: jest.fn() }));
 jest.mock("@/lib/RequestUtils", () => ({ RequestUtils: { getErrorStatus: jest.fn() } }));
 
 class MockResponse {
@@ -23,10 +25,18 @@ class MockResponse {
   }
 }
 
-const reqWithUrl = (url, body) => ({
-  nextUrl: new URL(url),
-  json: async () => body,
-});
+const reqWithUrl = (url, body, headers = {}) => {
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [String(key).toLowerCase(), value]),
+  );
+  return {
+    nextUrl: new URL(url),
+    headers: {
+      get: (name) => normalizedHeaders[String(name).toLowerCase()] ?? null,
+    },
+    json: async () => body,
+  };
+};
 
 describe("app/api/user route", () => {
   const originalResponse = global.Response;
@@ -41,56 +51,58 @@ describe("app/api/user route", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    authorizeUser.mockImplementation(async (_request, userInput) => Number.parseInt(String(userInput), 10));
     RequestUtils.getErrorStatus.mockImplementation((error, fallbackStatus = 400) => error?.status ?? fallbackStatus);
   });
 
-  test("GET without query returns all users with masked jwt", async () => {
-    UserService.getUsers.mockResolvedValue([{ id: 1, email: "a@a.com", jwt: "token" }]);
+  test("GET with id filter requires authorization and returns masked jwt", async () => {
+    UserService.filterUsers.mockResolvedValue([{ id: 1, email: "a@a.com", jwt: "token" }]);
 
-    const response = await GET(reqWithUrl("http://test/api/user"));
+    const response = await GET(
+      reqWithUrl("http://test/api/user?id=1", undefined, { authorization: "Bearer token" }),
+    );
     const body = await response.json();
 
+    expect(authorizeUser).toHaveBeenCalledWith(expect.any(Object), "1");
+    expect(UserService.filterUsers).toHaveBeenCalledWith({ id: "1" });
     expect(response.status).toBe(200);
     expect(body).toEqual([{ id: 1, email: "a@a.com", jwt: "PRIVATE" }]);
   });
 
-  test("GET with query filters users", async () => {
+  test("GET with email filter uses bearer token as jwt filter", async () => {
     UserService.filterUsers.mockResolvedValue([{ id: 2, email: "b@b.com", jwt: "t" }]);
 
-    const response = await GET(reqWithUrl("http://test/api/user?email=b%40b.com"));
+    const response = await GET(
+      reqWithUrl("http://test/api/user?email=b%40b.com", undefined, { authorization: "Bearer token" }),
+    );
     const body = await response.json();
 
-    expect(UserService.filterUsers).toHaveBeenCalledWith({ email: "b@b.com" });
+    expect(UserService.filterUsers).toHaveBeenCalledWith({ email: "b@b.com", jwt: "token" });
     expect(body).toEqual([{ id: 2, email: "b@b.com", jwt: "PRIVATE" }]);
   });
 
-  test("GET drops jwt filter when sanitized id/email filters are missing", async () => {
-    UserService.filterUsers.mockResolvedValue([]);
-
-    await GET(reqWithUrl("http://test/api/user?email=user%0A%40example.com&jwt=abcdef"));
-
-    expect(UserService.filterUsers).toHaveBeenCalledWith({});
-  });
-
-  test("GET returns 400 for jwt query with disallowed control characters", async () => {
-    const response = await GET(reqWithUrl("http://test/api/user?jwt=abc%0Adef"));
+  test("GET returns 400 when id/email filters are missing", async () => {
+    const response = await GET(reqWithUrl("http://test/api/user"));
     const body = await response.json();
 
     expect(UserService.filterUsers).not.toHaveBeenCalled();
     expect(response.status).toBe(400);
-    expect(body.message).toContain("Invalid user JWT");
+    expect(body.message).toContain("requires either 'id' or 'email' filter");
   });
 
-  test("GET forwards id/email/jwt query filters together", async () => {
-    UserService.filterUsers.mockResolvedValue([{ id: 2, email: "b@b.com", jwt: "t" }]);
+  test("GET returns 401 when bearer token is missing for email lookup", async () => {
+    const response = await GET(reqWithUrl("http://test/api/user?email=a%40a.com"));
+    const body = await response.json();
 
-    await GET(reqWithUrl("http://test/api/user?id=2&email=b%40b.com&jwt=token"));
-
-    expect(UserService.filterUsers).toHaveBeenCalledWith({ id: "2", email: "b@b.com", jwt: "token" });
+    expect(UserService.filterUsers).not.toHaveBeenCalled();
+    expect(response.status).toBe(401);
+    expect(body.message).toContain("Missing or invalid authorization header");
   });
 
   test("POST returns 400 when jwt is missing via PRIVATE placeholder", async () => {
-    const response = await POST(reqWithUrl("http://test/api/user", { email: "c@c.com", jwt: "PRIVATE" }));
+    const response = await POST(
+      reqWithUrl("http://test/api/user", { email: "c@c.com", jwt: "PRIVATE" }, { authorization: "Bearer token" }),
+    );
     const body = await response.json();
 
     expect(UserService.addUser).not.toHaveBeenCalled();
@@ -99,7 +111,9 @@ describe("app/api/user route", () => {
   });
 
   test("POST returns 400 when email is missing", async () => {
-    const response = await POST(reqWithUrl("http://test/api/user", { jwt: "token" }));
+    const response = await POST(
+      reqWithUrl("http://test/api/user", { jwt: "token" }, { authorization: "Bearer token" }),
+    );
     const body = await response.json();
 
     expect(UserService.addUser).not.toHaveBeenCalled();
@@ -108,7 +122,9 @@ describe("app/api/user route", () => {
   });
 
   test("POST returns 400 for invalid sanitized email payload", async () => {
-    const response = await POST(reqWithUrl("http://test/api/user", { email: "a b@x.com", jwt: "abc\ndef" }));
+    const response = await POST(
+      reqWithUrl("http://test/api/user", { email: "a b@x.com", jwt: "abc\ndef" }, { authorization: "Bearer abc\ndef" }),
+    );
     const body = await response.json();
 
     expect(UserService.addUser).not.toHaveBeenCalled();
@@ -117,29 +133,41 @@ describe("app/api/user route", () => {
   });
 
   test("POST returns error when payload is null", async () => {
-    UserService.addUser.mockImplementation(() => {
-      throw new TypeError("Cannot destructure null user payload");
-    });
-
-    const response = await POST(reqWithUrl("http://test/api/user", null));
+    const response = await POST(reqWithUrl("http://test/api/user", null, { authorization: "Bearer token" }));
     const body = await response.json();
 
-    expect(UserService.addUser).toHaveBeenCalledWith(null);
+    expect(UserService.addUser).not.toHaveBeenCalled();
     expect(response.status).toBe(400);
-    expect(body.message).toContain("Cannot add new user:");
+    expect(body.message).toContain("Invalid user payload");
+  });
+
+  test("POST returns 403 when bearer token does not match payload jwt", async () => {
+    const response = await POST(
+      reqWithUrl("http://test/api/user", { email: "c@c.com", jwt: "token-a" }, { authorization: "Bearer token-b" }),
+    );
+    const body = await response.json();
+
+    expect(UserService.addUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(403);
+    expect(body.message).toContain("User authorization failed");
   });
 
   test("PUT updates user by id", async () => {
     UserService.editUser.mockResolvedValue({ id: 3, email: "c@c.com", jwt: "" });
 
-    const response = await PUT(reqWithUrl("http://test/api/user?id=3", { email: "c@c.com", jwt: "PRIVATE" }));
+    const response = await PUT(
+      reqWithUrl("http://test/api/user?id=3", { email: "c@c.com", jwt: "PRIVATE" }, { authorization: "Bearer token" }),
+    );
 
     expect(response.status).toBe(200);
-    expect(UserService.editUser).toHaveBeenCalledWith("3", { email: "c@c.com", jwt: "" });
+    expect(authorizeUser).toHaveBeenCalledWith(expect.any(Object), "3");
+    expect(UserService.editUser).toHaveBeenCalledWith(3, { email: "c@c.com", jwt: "" });
   });
 
   test("PUT returns 400 for invalid sanitized JWT payload", async () => {
-    const response = await PUT(reqWithUrl("http://test/api/user?id=3", { email: "c@c.com", jwt: "\u202E" }));
+    const response = await PUT(
+      reqWithUrl("http://test/api/user?id=3", { email: "c@c.com", jwt: "\u202E" }, { authorization: "Bearer token" }),
+    );
     const body = await response.json();
 
     expect(UserService.editUser).not.toHaveBeenCalled();
@@ -148,7 +176,9 @@ describe("app/api/user route", () => {
   });
 
   test("PUT returns 400 for invalid sanitized email payload", async () => {
-    const response = await PUT(reqWithUrl("http://test/api/user?id=3", { email: "bad email", jwt: "x" }));
+    const response = await PUT(
+      reqWithUrl("http://test/api/user?id=3", { email: "bad email", jwt: "x" }, { authorization: "Bearer x" }),
+    );
     const body = await response.json();
 
     expect(UserService.editUser).not.toHaveBeenCalled();
@@ -159,17 +189,19 @@ describe("app/api/user route", () => {
   test("DELETE removes user by id", async () => {
     UserService.deleteUser.mockResolvedValue(1);
 
-    const response = await DELETE(reqWithUrl("http://test/api/user?id=3"));
+    const response = await DELETE(reqWithUrl("http://test/api/user?id=3", undefined, { authorization: "Bearer token" }));
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(authorizeUser).toHaveBeenCalledWith(expect.any(Object), "3");
+    expect(UserService.deleteUser).toHaveBeenCalledWith(3);
     expect(body).toEqual({ message: "Deleted 1 user(s)" });
   });
 
   test("GET returns mapped error status when service throws", async () => {
-    UserService.getUsers.mockRejectedValueOnce(Object.assign(new Error("db down"), { status: 503 }));
+    UserService.filterUsers.mockRejectedValueOnce(Object.assign(new Error("db down"), { status: 503 }));
 
-    const response = await GET(reqWithUrl("http://test/api/user"));
+    const response = await GET(reqWithUrl("http://test/api/user?id=1", undefined, { authorization: "Bearer token" }));
     const body = await response.json();
 
     expect(response.status).toBe(503);
@@ -179,7 +211,9 @@ describe("app/api/user route", () => {
   test("POST returns mapped error status when service throws", async () => {
     UserService.addUser.mockRejectedValueOnce(Object.assign(new Error("bad payload"), { status: 422 }));
 
-    const response = await POST(reqWithUrl("http://test/api/user", { email: "a@a.com", jwt: "x" }));
+    const response = await POST(
+      reqWithUrl("http://test/api/user", { email: "a@a.com", jwt: "x" }, { authorization: "Bearer x" }),
+    );
     const body = await response.json();
 
     expect(response.status).toBe(422);
@@ -189,7 +223,9 @@ describe("app/api/user route", () => {
   test("PUT returns mapped error status when service throws", async () => {
     UserService.editUser.mockRejectedValueOnce(Object.assign(new Error("update failed"), { status: 500 }));
 
-    const response = await PUT(reqWithUrl("http://test/api/user?id=3", { email: "c@c.com", jwt: "x" }));
+    const response = await PUT(
+      reqWithUrl("http://test/api/user?id=3", { email: "c@c.com", jwt: "x" }, { authorization: "Bearer token" }),
+    );
     const body = await response.json();
 
     expect(response.status).toBe(500);

--- a/tests/app/api/user/route.test.js
+++ b/tests/app/api/user/route.test.js
@@ -1,6 +1,8 @@
 import { GET, POST, PUT, DELETE } from "../../../../src/app/api/user/route.js";
 import { UserService } from "@/model/UserService";
 import { authorizeUser, requireBearerToken } from "@/lib/ApiUserAuth";
+import { getEmailFromJwt } from "@/lib/AuthTokenUtils";
+import { ScraperRequest } from "@/lib/ScraperRequest";
 import { RequestUtils } from "@/lib/RequestUtils";
 
 jest.mock("@/model/UserService", () => ({
@@ -13,6 +15,12 @@ jest.mock("@/model/UserService", () => ({
   },
 }));
 jest.mock("@/lib/ApiUserAuth", () => ({ authorizeUser: jest.fn(), requireBearerToken: jest.fn() }));
+jest.mock("@/lib/AuthTokenUtils", () => ({ getEmailFromJwt: jest.fn() }));
+jest.mock("@/lib/ScraperRequest", () => ({
+  ScraperRequest: {
+    GET: jest.fn(),
+  },
+}));
 jest.mock("@/lib/RequestUtils", () => ({ RequestUtils: { getErrorStatus: jest.fn() } }));
 
 class MockResponse {
@@ -67,6 +75,8 @@ describe("app/api/user route", () => {
       }
       return token;
     });
+    getEmailFromJwt.mockReturnValue("user@example.com");
+    ScraperRequest.GET.mockResolvedValue({ ok: true, status: 200 });
     RequestUtils.getErrorStatus.mockImplementation((error, fallbackStatus = 400) => error?.status ?? fallbackStatus);
   });
 
@@ -174,6 +184,46 @@ describe("app/api/user route", () => {
     expect(UserService.addUser).not.toHaveBeenCalled();
     expect(response.status).toBe(403);
     expect(body.message).toContain("User authorization failed");
+  });
+
+  test("POST returns 403 when token email does not match payload email", async () => {
+    getEmailFromJwt.mockReturnValueOnce("attacker@example.com");
+
+    const response = await POST(
+      reqWithUrl("http://test/api/user", { email: "user@example.com", jwt: "token" }, { authorization: "Bearer token" }),
+    );
+    const body = await response.json();
+
+    expect(ScraperRequest.GET).not.toHaveBeenCalled();
+    expect(UserService.addUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(403);
+    expect(body.message).toContain("User authorization failed");
+  });
+
+  test("POST returns 403 when scraper token validation fails", async () => {
+    ScraperRequest.GET.mockResolvedValueOnce({ ok: false, status: 401 });
+
+    const response = await POST(
+      reqWithUrl("http://test/api/user", { email: "user@example.com", jwt: "token" }, { authorization: "Bearer token" }),
+    );
+    const body = await response.json();
+
+    expect(UserService.addUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(403);
+    expect(body.message).toContain("User authorization failed");
+  });
+
+  test("POST returns 503 when scraper backend cannot validate token", async () => {
+    ScraperRequest.GET.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const response = await POST(
+      reqWithUrl("http://test/api/user", { email: "user@example.com", jwt: "token" }, { authorization: "Bearer token" }),
+    );
+    const body = await response.json();
+
+    expect(UserService.addUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(503);
+    expect(body.message).toContain("Cannot validate user token with scraper backend");
   });
 
   test("PUT updates user by id", async () => {

--- a/tests/app/api/user/route.test.js
+++ b/tests/app/api/user/route.test.js
@@ -213,6 +213,19 @@ describe("app/api/user route", () => {
     expect(body.message).toContain("User authorization failed");
   });
 
+  test("POST validates token using lightweight scraper items probe", async () => {
+    UserService.addUser.mockResolvedValueOnce({ id: 7, email: "user@example.com", jwt: "token" });
+
+    await POST(
+      reqWithUrl("http://test/api/user", { email: "user@example.com", jwt: "token" }, { authorization: "Bearer token" }),
+    );
+
+    expect(ScraperRequest.GET).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/data/items?name=__token_validation_probe__"),
+      { Authorization: "Bearer token" },
+    );
+  });
+
   test("POST returns 503 when scraper backend cannot validate token", async () => {
     ScraperRequest.GET.mockResolvedValueOnce({ ok: false, status: 500 });
 

--- a/tests/app/api/user/route.test.js
+++ b/tests/app/api/user/route.test.js
@@ -1,6 +1,6 @@
 import { GET, POST, PUT, DELETE } from "../../../../src/app/api/user/route.js";
 import { UserService } from "@/model/UserService";
-import { authorizeUser } from "@/lib/ApiUserAuth";
+import { authorizeUser, requireBearerToken } from "@/lib/ApiUserAuth";
 import { RequestUtils } from "@/lib/RequestUtils";
 
 jest.mock("@/model/UserService", () => ({
@@ -12,7 +12,7 @@ jest.mock("@/model/UserService", () => ({
     deleteUser: jest.fn(),
   },
 }));
-jest.mock("@/lib/ApiUserAuth", () => ({ authorizeUser: jest.fn() }));
+jest.mock("@/lib/ApiUserAuth", () => ({ authorizeUser: jest.fn(), requireBearerToken: jest.fn() }));
 jest.mock("@/lib/RequestUtils", () => ({ RequestUtils: { getErrorStatus: jest.fn() } }));
 
 class MockResponse {
@@ -52,6 +52,21 @@ describe("app/api/user route", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     authorizeUser.mockImplementation(async (_request, userInput) => Number.parseInt(String(userInput), 10));
+    requireBearerToken.mockImplementation((request) => {
+      const authorization = request.headers?.get("authorization") || "";
+      if (!authorization.toLowerCase().startsWith("bearer ")) {
+        const error = new Error("Missing or invalid authorization header.");
+        error.status = 401;
+        throw error;
+      }
+      const token = authorization.substring(7).trim();
+      if (!token) {
+        const error = new Error("Missing or invalid authorization header.");
+        error.status = 401;
+        throw error;
+      }
+      return token;
+    });
     RequestUtils.getErrorStatus.mockImplementation((error, fallbackStatus = 400) => error?.status ?? fallbackStatus);
   });
 
@@ -73,11 +88,11 @@ describe("app/api/user route", () => {
     UserService.filterUsers.mockResolvedValue([{ id: 2, email: "b@b.com", jwt: "t" }]);
 
     const response = await GET(
-      reqWithUrl("http://test/api/user?email=b%40b.com", undefined, { authorization: "Bearer token" }),
+      reqWithUrl("http://test/api/user?email=user%40example.com", undefined, { authorization: "Bearer token" }),
     );
     const body = await response.json();
 
-    expect(UserService.filterUsers).toHaveBeenCalledWith({ email: "b@b.com", jwt: "token" });
+    expect(UserService.filterUsers).toHaveBeenCalledWith({ email: "user@example.com", jwt: "token" });
     expect(body).toEqual([{ id: 2, email: "b@b.com", jwt: "PRIVATE" }]);
   });
 
@@ -91,12 +106,21 @@ describe("app/api/user route", () => {
   });
 
   test("GET returns 401 when bearer token is missing for email lookup", async () => {
-    const response = await GET(reqWithUrl("http://test/api/user?email=a%40a.com"));
+    const response = await GET(reqWithUrl("http://test/api/user?email=user%40example.com"));
     const body = await response.json();
 
     expect(UserService.filterUsers).not.toHaveBeenCalled();
     expect(response.status).toBe(401);
     expect(body.message).toContain("Missing or invalid authorization header");
+  });
+
+  test("GET returns 400 for invalid email filter", async () => {
+    const response = await GET(reqWithUrl("http://test/api/user?email=not-an-email", undefined, { authorization: "Bearer t" }));
+    const body = await response.json();
+
+    expect(UserService.filterUsers).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("Invalid user email filter");
   });
 
   test("POST returns 400 when jwt is missing via PRIVATE placeholder", async () => {
@@ -143,7 +167,7 @@ describe("app/api/user route", () => {
 
   test("POST returns 403 when bearer token does not match payload jwt", async () => {
     const response = await POST(
-      reqWithUrl("http://test/api/user", { email: "c@c.com", jwt: "token-a" }, { authorization: "Bearer token-b" }),
+      reqWithUrl("http://test/api/user", { email: "user@example.com", jwt: "token-a" }, { authorization: "Bearer token-b" }),
     );
     const body = await response.json();
 
@@ -173,6 +197,17 @@ describe("app/api/user route", () => {
     expect(UserService.editUser).not.toHaveBeenCalled();
     expect(response.status).toBe(400);
     expect(body.message).toContain("Invalid user JWT");
+  });
+
+  test("PUT returns 400 when email is missing", async () => {
+    const response = await PUT(
+      reqWithUrl("http://test/api/user?id=3", { jwt: "x" }, { authorization: "Bearer x" }),
+    );
+    const body = await response.json();
+
+    expect(UserService.editUser).not.toHaveBeenCalled();
+    expect(response.status).toBe(400);
+    expect(body.message).toContain("User email is required");
   });
 
   test("PUT returns 400 for invalid sanitized email payload", async () => {
@@ -212,7 +247,7 @@ describe("app/api/user route", () => {
     UserService.addUser.mockRejectedValueOnce(Object.assign(new Error("bad payload"), { status: 422 }));
 
     const response = await POST(
-      reqWithUrl("http://test/api/user", { email: "a@a.com", jwt: "x" }, { authorization: "Bearer x" }),
+      reqWithUrl("http://test/api/user", { email: "user@example.com", jwt: "x" }, { authorization: "Bearer x" }),
     );
     const body = await response.json();
 

--- a/tests/components/MenuBar.test.jsx
+++ b/tests/components/MenuBar.test.jsx
@@ -148,4 +148,23 @@ describe("MenuBar", () => {
       expect(toastWarnMock).toHaveBeenCalledWith("Logout successful. Warning: Cannot remove demo user");
     });
   });
+
+  test("demo logout warns when token is missing before cleanup call", async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true });
+    const logoutMock = jest.fn();
+
+    renderWithContexts({
+      login: { isDemo: true, challenge: "abc", logout: logoutMock, userId: () => 7357, token: null },
+      page: { pageId: "monitors" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "logout" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(logoutMock).toHaveBeenCalled();
+      expect(replaceMock).toHaveBeenCalledWith("/");
+      expect(toastWarnMock).toHaveBeenCalledWith("Logout successful. Warning: Missing user token");
+    });
+  });
 });

--- a/tests/components/MenuBar.test.jsx
+++ b/tests/components/MenuBar.test.jsx
@@ -58,7 +58,7 @@ describe("MenuBar", () => {
 
   test("shows notifiers button on monitors page", () => {
     renderWithContexts({
-      login: { isDemo: false, challenge: "abc", logout: jest.fn(), userId: () => 11 },
+      login: { isDemo: false, challenge: "abc", logout: jest.fn(), userId: () => 11, token: "tkn" },
       page: { pageId: "monitors" },
     });
 
@@ -67,7 +67,7 @@ describe("MenuBar", () => {
 
   test("shows monitors button on notifiers page", () => {
     renderWithContexts({
-      login: { isDemo: false, challenge: "abc", logout: jest.fn(), userId: () => 11 },
+      login: { isDemo: false, challenge: "abc", logout: jest.fn(), userId: () => 11, token: "tkn" },
       page: { pageId: "notifiers" },
     });
 
@@ -76,7 +76,7 @@ describe("MenuBar", () => {
 
   test("navigates to scraper config with challenge", () => {
     renderWithContexts({
-      login: { isDemo: false, challenge: "abc", logout: jest.fn(), userId: () => 11 },
+      login: { isDemo: false, challenge: "abc", logout: jest.fn(), userId: () => 11, token: "tkn" },
       page: { pageId: "monitors" },
     });
 
@@ -89,7 +89,7 @@ describe("MenuBar", () => {
     const logoutMock = jest.fn();
 
     renderWithContexts({
-      login: { isDemo: false, challenge: "abc", logout: logoutMock, userId: () => 11 },
+      login: { isDemo: false, challenge: "abc", logout: logoutMock, userId: () => 11, token: "tkn" },
       page: { pageId: "monitors" },
     });
 
@@ -108,7 +108,7 @@ describe("MenuBar", () => {
     const logoutMock = jest.fn();
 
     renderWithContexts({
-      login: { isDemo: true, challenge: "abc", logout: logoutMock, userId: () => 7357 },
+      login: { isDemo: true, challenge: "abc", logout: logoutMock, userId: () => 7357, token: "demo-token" },
       page: { pageId: "monitors" },
     });
 
@@ -119,7 +119,10 @@ describe("MenuBar", () => {
       expect(global.fetch).toHaveBeenNthCalledWith(
         2,
         "/api/user?id=7357",
-        expect.objectContaining({ method: "DELETE" }),
+        expect.objectContaining({
+          method: "DELETE",
+          headers: expect.objectContaining({ Authorization: "Bearer demo-token" }),
+        }),
       );
       expect(logoutMock).toHaveBeenCalled();
       expect(replaceMock).toHaveBeenCalledWith("/");
@@ -132,7 +135,7 @@ describe("MenuBar", () => {
     const logoutMock = jest.fn();
 
     renderWithContexts({
-      login: { isDemo: true, challenge: "abc", logout: logoutMock, userId: () => 7357 },
+      login: { isDemo: true, challenge: "abc", logout: logoutMock, userId: () => 7357, token: "demo-token" },
       page: { pageId: "monitors" },
     });
 

--- a/tests/model/UserService.test.js
+++ b/tests/model/UserService.test.js
@@ -87,7 +87,7 @@ describe("UserService", () => {
         expect(edited.jwt).toBe("current-jwt");
 
         const deleted = await UserService.deleteUser(2);
-        expect(deleted).toBe(true);
+        expect(deleted).toBe(1);
         expect(calls[4].params).toEqual([2]);
       },
     );

--- a/tests/views/HomePage.test.jsx
+++ b/tests/views/HomePage.test.jsx
@@ -85,6 +85,9 @@ describe("HomePage", () => {
     expect(global.fetch).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining("/api/user?"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer jwt-token" }),
+      }),
     );
     expect(global.fetch.mock.calls[1][0]).toContain("email=user%40example.com");
   });
@@ -171,7 +174,10 @@ describe("HomePage", () => {
       expect(global.fetch).toHaveBeenNthCalledWith(
         3,
         "/api/user",
-        expect.objectContaining({ method: "POST" }),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ Authorization: "Bearer jwt-token" }),
+        }),
       );
       expect(toastErrorMock).toHaveBeenCalledWith("create failed");
       expect(loginMock).not.toHaveBeenCalled();
@@ -205,7 +211,10 @@ describe("HomePage", () => {
       expect(global.fetch).toHaveBeenNthCalledWith(
         3,
         "/api/user?id=42",
-        expect.objectContaining({ method: "PUT" }),
+        expect.objectContaining({
+          method: "PUT",
+          headers: expect.objectContaining({ Authorization: "Bearer jwt-token" }),
+        }),
       );
       expect(toastErrorMock).toHaveBeenCalledWith("update failed");
       expect(loginMock).not.toHaveBeenCalled();
@@ -268,6 +277,12 @@ describe("HomePage", () => {
       expect(global.fetch).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining("/api/user?"),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization:
+              "Bearer header.eyJlbWFpbCI6ImRlbW9AZXhhbXBsZS5jb20ifQ.signature",
+          }),
+        }),
       );
       expect(global.fetch.mock.calls[1][0]).toContain("email=demo%40example.com");
       expect(demoMock).toHaveBeenCalledWith(


### PR DESCRIPTION
This patch fixes #112 
Now all API user endpoints can be invoked only by authorized users (bearer token is required). 
OpenAPI and tests were also updated.